### PR TITLE
fix: correct the typography of the `oldPassword` argument

### DIFF
--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -341,7 +341,7 @@ export default class ApiClient {
     })
   }
 
-  updatePassword(params: { accessToken?: string, password: string, oldPasssord?: string, userId?: string }): Promise<void> {
+  updatePassword(params: { accessToken?: string, password: string, oldPassword?: string, userId?: string }): Promise<void> {
     const { accessToken, ...data } = params
     return this.http.post('/update-password', {
       body: { clientId: this.config.clientId, ...data },

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -37,7 +37,7 @@ export type Client = {
   getUser: (params: { accessToken: string; fields?: string }) => Promise<Profile>
   updateProfile: (params: { accessToken: string; data: Profile }) => Promise<void>
   updateEmail: (params: { accessToken: string; email: string }) => Promise<void>
-  updatePassword: (params: { accessToken?: string; password: string; oldPasssord?: string; userId?: string }) => Promise<void>
+  updatePassword: (params: { accessToken?: string; password: string; oldPassword?: string; userId?: string }) => Promise<void>
   updatePhoneNumber: (params: { accessToken: string; phoneNumber: string }) => Promise<void>
   verifyPhoneNumber: (params: { accessToken: string; phoneNumber: string; verificationCode: string }) => Promise<void>
   loginWithCustomToken: (params: { token: string; auth: AuthOptions }) => Promise<void>
@@ -122,7 +122,7 @@ export function createClient(creationConfig: Config): Client {
     return apiClient.then(api => api.updateEmail(params))
   }
 
-  function updatePassword(params: { accessToken?: string, password: string, oldPasssord?: string, userId?: string }) {
+  function updatePassword(params: { accessToken?: string, password: string, oldPassword?: string, userId?: string }) {
     return apiClient.then(api => api.updatePassword(params))
   }
 


### PR DESCRIPTION
**Asana ticket**: https://app.asana.com/0/1111569008372652/1113601549747565

I've fixed the typography of the `oldPassword` argument passed to the `updatePassword` method.

The dev documentation was already correct (https://developer.reach5.co/api/identity-web/#updatepassword).