### PR TITLE
Fix the typography of the `oldPassword` argument

### DIFF
--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -323,7 +323,7 @@ export default class ApiClient {
     })
   }
 
-  updatePassword(params: { accessToken?: string, password: string, oldPasssord?: string, userId?: string }) {
+  updatePassword(params: { accessToken?: string, password: string, oldPassword?: string, userId?: string }) {
     const { accessToken, ...data } = params
     return this.requestPost(
       '/update-password',

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -66,7 +66,7 @@ export function createClient(config: ApiClientConfig) {
     return apiClient.then(api => api.updateEmail(params))
   }
 
-  function updatePassword(params: { accessToken?: string, password: string, oldPasssord?: string, userId?: string }) {
+  function updatePassword(params: { accessToken?: string, password: string, oldPassword?: string, userId?: string }) {
     return apiClient.then(api => api.updatePassword(params))
   }
 


### PR DESCRIPTION
**Asana ticket**: https://app.asana.com/0/1111569008372652/1113601549747565

I've fixed the typography of the `oldPassword` argument passed to the `updatePassword` method.

The dev documentation was already correct (https://developer.reach5.co/api/identity-web/#updatepassword).