### PR TITLE
fix: fix the regex for the 'deploy-alpha' task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ workflows:
             - test
           filters:
             tags:
-              only: /^v*-alpha\.[0-9]/
+              only: /^v.*-alpha\.[0-9]/
             branches:
               ignore: /.*/
       - deploy-release:


### PR DESCRIPTION
No Asana task for this PR.

In fact the `.` was a metacharacter used to match almost any character.