### PR TITLE
fix: update the deploy-alpha regex to include the complete alpha's number

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,6 @@ workflows:
             - test
           filters:
             tags:
-              only: /^v.*-alpha\.[0-9]/
+              only: /^v.*-alpha\..[0-9]/
             branches:
               ignore: /.*/


### PR DESCRIPTION
No Asana task.

The current `deploy-alpha` task's regex (`/^v.*-alpha\.[0-9]/`) doesn't match the `v0.1.0-alpha.14` version.