### PR TITLE
fix: fix the circleci config to publish automatically the library on npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,10 @@ workflows:
   version: 2
   npm-deploy:
     jobs:
-      - test
+      - test:
+          filters:
+            tags:
+              only: /.*/
       - deploy-alpha:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,25 +14,19 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-
       # Download and cache dependencies
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "package.json" }}
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
-
       - run: npm install
-
       - save_cache:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-
       - run: npm run build
-      
       - run: npm test
-    
       - persist_to_workspace:
           root: ~/repo
           paths: .

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -1,0 +1,29 @@
+# Guide for publication
+
+1. Describe the new features and bug fixes in the [CHANGELOG.md](CHANGELOG.md).
+
+2. Update the package's version with the command line below. It should only be `0.1.0-alpha.x` versions.
+
+    ```sh
+    npm version prerelease --preid=alpha
+    ```
+
+    This commands will update the version in the [`package.json`](package.json) file and will create a new tag (eg: `v0.1.0-alpha.15`).
+
+3. Push the two latest commits.
+
+    ```sh
+    git push -u origin <branch_name>
+    ```
+
+    Push the new tag.
+   
+    ```sh
+    git push origin <tag_name> 
+    ```
+
+    [circleci](https://circleci.com/) will automatically trigger a build, run the tests and publish the new version of the SDK on [`npm`](https://www.npmjs.com/package/@reachfive/identity-core).
+
+    > It's important to push the tag separately otherwise the deployement job is not triggered (https://support.circleci.com/hc/en-us/articles/115013854347-Jobs-builds-not-triggered-when-pushing-tag).
+
+    Refer to the [.circleci/config.yml](.circleci/config.yml) file to set up the integration.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-# Reach5 Identity Web Core SDK
+# Reach5 Identity Web Core SDK (legacy)
 
-This compatibility branch should only contain `0.1.x` versions and mimicks the behavior of the historical <script> based API.
+This compatibility branch should mimicks the behavior of the historical <script> based API.
 
 For the up to date library, check the `master` branch.
-
-## How to use

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "build": "rollup -c",
     "watch": "rollup -c -w",
-    "test": "jest",
+    "test": "jest --runInBand",
     "watch:test": "jest --watch",
     "prepublish": "yarn build"
   },


### PR DESCRIPTION
**Asana task**: https://app.asana.com/0/1111569008372652/1114752046756483

- I've added the option `--runInBand` in the test command to prevent timeouts during continuous integration (https://jestjs.io/docs/en/troubleshooting.html#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server)
- I've added a filter to the `test` task (https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag)
<img width="886" alt="Screenshot 2019-03-19 at 16 54 50" src="https://user-images.githubusercontent.com/9531852/54621250-bf1dd100-4a67-11e9-8532-72451f6e2104.png">
