### PR TITLE
feature: update the signature of the `loginWithPassword` method (master)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 .rpt2_cache
 .DS_Store
 .idea
+.vscode

--- a/src/main/__tests__/loginWithPassword.spec.ts
+++ b/src/main/__tests__/loginWithPassword.spec.ts
@@ -10,7 +10,7 @@ beforeEach(() => {
   window.location.assign = jest.fn()
 })
 
-test('Login with default auth config (email/password)', async () => {
+test('with default auth config (email/password)', async () => {
   // Given
   const { api, clientId, domain } = createDefaultTestClient()
 
@@ -46,7 +46,7 @@ test('Login with default auth config (email/password)', async () => {
   )
 })
 
-test('Login with default auth config (phone/password)', async () => {
+test('with default auth config (phone/password)', async () => {
   // Given
   const { api, clientId, domain } = createDefaultTestClient()
 
@@ -82,7 +82,7 @@ test('Login with default auth config (phone/password)', async () => {
   )
 })
 
-test('Login with popup mode (email/password)', async () => {
+test('with popup mode (email/password)', async () => {
   // Given
   const { api, clientId, domain } = createDefaultTestClient()
 
@@ -124,7 +124,7 @@ test('Login with popup mode (email/password)', async () => {
   )
 })
 
-test('Login with default auth (email/password)', async () => {
+test('with default auth (email/password)', async () => {
   // Given
   const { api, clientId, domain } = createDefaultTestClient()
 
@@ -170,7 +170,7 @@ test('Login with default auth (email/password)', async () => {
   )
 })
 
-test('Don\'t login if the password is wrong (email/password)', async () => {
+test('with error if the password is wrong (email/password)', async () => {
   // Given
   const { api } = createDefaultTestClient()
 
@@ -202,7 +202,7 @@ test('Don\'t login if the password is wrong (email/password)', async () => {
   expect(loginFailedHandler).toHaveBeenCalledWith(expectedError)
 })
 
-test('Don\'t login if the password is wrong (phone number/password)', async () => {
+test('with error if the password is wrong (phone number/password)', async () => {
   // Given
   const { api } = createDefaultTestClient()
 

--- a/src/main/__tests__/loginWithPassword.spec.ts
+++ b/src/main/__tests__/loginWithPassword.spec.ts
@@ -192,7 +192,7 @@ test('Don\'t login if the password is wrong (email/password)', async () => {
   // When
   let error = null
   api
-    .loginWithPassword( { email: 'john.doe@example.com', password: 'majefize' } )
+    .loginWithPassword({ email: 'john.doe@example.com', password: 'majefize' })
     .catch(err => error = err)
 
   await delay(1)
@@ -224,7 +224,7 @@ test('Don\'t login if the password is wrong (phone number/password)', async () =
   // When
   let error = null
   api
-    .loginWithPassword( { phoneNumber: '+33761331332', password: 'majefize' } )
+    .loginWithPassword({ phoneNumber: '+33761331332', password: 'majefize' })
     .catch(err => error = err)
 
   await delay(1)

--- a/src/main/__tests__/loginWithPassword.spec.ts
+++ b/src/main/__tests__/loginWithPassword.spec.ts
@@ -10,7 +10,7 @@ beforeEach(() => {
   window.location.assign = jest.fn()
 })
 
-test('with default auth', async () => {
+test('Login with default auth config (email/password)', async () => {
   // Given
   const { api, clientId, domain } = createDefaultTestClient()
 
@@ -18,10 +18,7 @@ test('with default auth', async () => {
   const password = 'izDf8£Zd'
 
   const passwordToken = 'password_token'
-
-  const passwordLoginCall = fetchMock.mockResponseOnce(JSON.stringify({
-    tkn: passwordToken
-  }))
+  const passwordLoginCall = fetchMock.mockResponseOnce(JSON.stringify({ tkn: passwordToken }))
 
   // When
   let error = null
@@ -49,7 +46,43 @@ test('with default auth', async () => {
   )
 })
 
-test('popup mode is ignored', async () => {
+test('Login with default auth config (phone/password)', async () => {
+  // Given
+  const { api, clientId, domain } = createDefaultTestClient()
+
+  const phoneNumber = '+33761331332'
+  const password = 'izDf8£Zd'
+
+  const passwordToken = 'password_token'
+  const passwordLoginCall = fetchMock.mockResponseOnce(JSON.stringify({ tkn: passwordToken }))
+
+  // When
+  let error = null
+  api.loginWithPassword({ phoneNumber, password }).catch(err => error = err)
+
+  await delay(1)
+
+  // Then
+  expect(error).toBeNull()
+
+  expect(passwordLoginCall).toHaveBeenCalledWith(`https://${domain}/identity/v1/password/login`, {
+    method: 'POST',
+    headers: headers.jsonAndDefaultLang,
+    body: `{"client_id":"${clientId}","phone_number":"${phoneNumber}","password":"${password}"}`
+  })
+
+  expect(window.location.assign).toHaveBeenCalledWith(
+    `https://${domain}/identity/v1/password/callback?` + toQueryString({
+      'client_id': clientId,
+      'response_type': 'token',
+      'scope': 'openid profile email phone',
+      'display': 'page',
+      'tkn': passwordToken
+    })
+  )
+})
+
+test('Login with popup mode (email/password)', async () => {
   // Given
   const { api, clientId, domain } = createDefaultTestClient()
 
@@ -59,9 +92,7 @@ test('popup mode is ignored', async () => {
   const passwordToken = 'password_token_2'
   const redirectUri = 'http://mysite.com/login/callback'
 
-  fetchMock.mockResponseOnce(JSON.stringify({
-    tkn: passwordToken
-  }))
+  fetchMock.mockResponseOnce(JSON.stringify({ tkn: passwordToken }))
 
   // When
   let error = null
@@ -93,7 +124,7 @@ test('popup mode is ignored', async () => {
   )
 })
 
-test('with default auth', async () => {
+test('Login with default auth (email/password)', async () => {
   // Given
   const { api, clientId, domain } = createDefaultTestClient()
 
@@ -101,10 +132,7 @@ test('with default auth', async () => {
   const password = 'izDf8£Zd'
 
   const passwordToken = 'password_token'
-
-  const passwordLoginCall = fetchMock.mockResponseOnce(JSON.stringify({
-    tkn: passwordToken
-  }))
+  const passwordLoginCall = fetchMock.mockResponseOnce(JSON.stringify({ tkn: passwordToken }))
 
   // When
   let error = null
@@ -142,7 +170,7 @@ test('with default auth', async () => {
   )
 })
 
-test('with user error', async () => {
+test('Don\'t login if the password is wrong (email/password)', async () => {
   // Given
   const { api } = createDefaultTestClient()
 
@@ -163,12 +191,41 @@ test('with user error', async () => {
 
   // When
   let error = null
-  api.loginWithPassword(
-    {
-      email: 'john.doe@example.com',
-      password: 'majefize'
-    }
-  ).catch(err => error = err)
+  api
+    .loginWithPassword( { email: 'john.doe@example.com', password: 'majefize' } )
+    .catch(err => error = err)
+
+  await delay(1)
+
+  // Then
+  expect(error).toEqual(expectedError)
+  expect(loginFailedHandler).toHaveBeenCalledWith(expectedError)
+})
+
+test('Don\'t login if the password is wrong (phone number/password)', async () => {
+  // Given
+  const { api } = createDefaultTestClient()
+
+  const loginFailedHandler = jest.fn()
+  api.on('login_failed', loginFailedHandler)
+
+  const expectedError = {
+    error: 'invalid_grant',
+    errorDescription: 'Invalid phone number or password',
+    errorUsrMsg: 'Invalid phone number or password'
+  }
+
+  fetchMock.mockResponseOnce(JSON.stringify({
+    'error': 'invalid_grant',
+    'error_description': 'Invalid phone number or password',
+    'error_usr_msg': 'Invalid phone number or password'
+  }), { status: 400 })
+
+  // When
+  let error = null
+  api
+    .loginWithPassword( { phoneNumber: '+33761331332', password: 'majefize' } )
+    .catch(err => error = err)
 
   await delay(1)
 

--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -432,6 +432,6 @@ export default class ApiClient {
   }
 }
 
-function hasLoggedWithEmail (params: LoginWithPasswordParams): params is EmailLoginWithPasswordParams {
-  return Boolean((<EmailLoginWithPasswordParams>params).email)
+function hasLoggedWithEmail(params: LoginWithPasswordParams): params is EmailLoginWithPasswordParams {
+  return Boolean((params as EmailLoginWithPasswordParams).email)
 }

--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -433,5 +433,5 @@ export default class ApiClient {
 }
 
 function hasLoggedWithEmail(params: LoginWithPasswordParams): params is EmailLoginWithPasswordParams {
-  return Boolean((params as EmailLoginWithPasswordParams).email)
+  return ((params as EmailLoginWithPasswordParams).email) !== undefined
 }


### PR DESCRIPTION
**Asana task**: https://app.asana.com/0/1111569008372652/1124648595362033

I've updated the signature of the `loginWithPassword` to also accept phone numbers.

Same changes than https://github.com/ReachFive/identity-web-core-sdk/pull/24 but on the `master` branch.