### PR TITLE
Release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 
+## v1.3.0
+
+### 11 juin 2019
+
+### Features
+- Update the signature of the `loginWithPassword` method to handle login with a phone number.
+
 ## v1.2.1
 
-### 21 Mars 2019
+### 21 mars 2019
 
 #### Improvements
 - Remove validation.ts library
@@ -13,7 +20,7 @@
 
 ## v1.1.4
 
-### 21 Mars 2019
+### 21 mars 2019
 
 #### Improvements
 
@@ -21,7 +28,7 @@ Automatise the deployment of a new release with `circleci`.
 
 ## v1.1.3
 
-### 15 Mars 2019
+### 15 mars 2019
 
 #### Fixes and improvements
 - Fix the typography of the `oldPassword` argument of the [`updatePassword`](src/main/apiClient.ts) method.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@reachfive/identity-core",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reachfive/identity-core",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Reach5 Identity Web Core SDK",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
- Update the changelog.
- Bump the version to `v1.3.0`.