### PR TITLE
Downgrade the lodash dependency's version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,15 +45,15 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.136",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.136.tgz",
-      "integrity": "sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==",
+      "version": "4.14.134",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.134.tgz",
+      "integrity": "sha512-2/O0khFUCFeDlbi7sZ7ZFRCcT812fAeOLm7Ev4KbwASkZ575TDrDcY7YyaoHdTOzKcNbfiwLYZqPmoC4wadrsw==",
       "dev": true
     },
     "@types/lodash-es": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.3.tgz",
-      "integrity": "sha512-iHI0i7ZAL1qepz1Y7f3EKg/zUMDwDfTzitx+AlHhJJvXwenP682ZyGbgPSc5Ej3eEAKVbNWKFuwOadCj5vBbYQ==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.1.tgz",
+      "integrity": "sha512-3EDZjphPfdjnsWvY11ufYImFMPyQJwIH1eFYRgWQsjOctce06fmNgVf5sfvXBRiaS1o0X50bAln1lfWs8ZO3BA==",
       "dev": true,
       "requires": {
         "@types/lodash": "*"
@@ -3525,14 +3525,14 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash-es": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
+      "integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
   "module": "es/main.js",
   "typings": "es/main/main.d.ts",
   "dependencies": {
-    "lodash": "^4.17.15",
-    "lodash-es": "4.17.15",
+    "lodash": "^4.17.11",
+    "lodash-es": "4.17.10",
     "validation.ts": "0.0.23",
     "winchan": "0.2.0"
   },
   "devDependencies": {
     "@types/jest": "23.3.1",
-    "@types/lodash-es": "4.17.3",
+    "@types/lodash-es": "4.17.1",
     "jest": "23.6.0",
     "jest-fetch-mock": "1.6.6",
     "rollup": "0.65.2",


### PR DESCRIPTION
I have downgraded the version of the `lodash` and `lodash-es` dependencies since the latest version breaks the SDK tests. It's currently blocking the ciam-app release so I've put the previous version back. I'll do some more tests later.