### PR TITLE
Release v0.1.0-alpha.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.0-alpha.20
+
+### 06/08/2019
+
+### Fixes
+- The `lodash` dependency was temporary downgraded since it broke tests.
+
 ## 0.1.0-alpha.19
 
 ### 05/08/2019

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@reachfive/identity-core",
-  "version": "0.1.0-alpha.19",
+  "version": "0.1.0-alpha.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reachfive/identity-core",
-  "version": "0.1.0-alpha.19",
+  "version": "0.1.0-alpha.20",
   "license": "MIT",
   "main": "cjs/main.js",
   "module": "es/main.js",


### PR DESCRIPTION
- Update changelog.
- Bump version to `v0.1.0-alpha.19`.