### PR TITLE
fix custom fields and cosents case conversions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@reachfive/identity-core",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/utils/transformObjectProperties.ts
+++ b/src/utils/transformObjectProperties.ts
@@ -18,6 +18,12 @@ export const camelCasePath = (path: string) =>
 export const camelCaseProperties = (object: object) => transformObjectProperties(object, camelCase)
 export const snakeCaseProperties = (object: object) => transformObjectProperties(object, snakeCase)
 
+/**
+ * Won't convert the value of the field, but the field key will be converted.
+ * The values in this list should be in snake_case.
+ */
+const fieldsNotToConvert = ['custom_fields', 'consents']
+
 function transformObjectProperties(object: any, transform: (path: string) => string): any {
   if (isArray(object)) {
     return object.map(o => transformObjectProperties(o, transform))
@@ -25,7 +31,8 @@ function transformObjectProperties(object: any, transform: (path: string) => str
     return reduce(
       object,
       (acc, value, key) => {
-        acc[transform(key)] = transformObjectProperties(value, transform)
+        acc[transform(key)] = fieldsNotToConvert.find(s => s === snakeCase(key)) ?
+          value : transformObjectProperties(value, transform)
         return acc
       },
       {} as Record<string, unknown>


### PR DESCRIPTION
Pour enfin en finir avec les problème de case conversion sur les keys des custom fields et consents.

Testé (avec moult douleurs) sur la nouvelle sandbox :
1- Link la nouvelle sandbox avec la nouvelle version du sdk `cd ciam-app/frontend/sandbox && npm install /path/to/identity-web-core-sdk`
2- Modifier la sandbox pour qu'elle envoie un custom fieds non corect (ex : a1a1)
3- avec l'ancienne version, cela provoque une erreur, avec la nouvelle, cela ne provoque aucune erreur.