### PR TITLE
Export remote settings and the `ErrorResponse` model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,9 +45,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.132",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.132.tgz",
-      "integrity": "sha512-RNUU1rrh85NgUJcjOOr96YXr+RHwInGbaQCZmlitqOaCKXffj8bh+Zxwuq5rjDy5OgzFldDVoqk4pyLEDiwxIw==",
+      "version": "4.14.144",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.144.tgz",
+      "integrity": "sha512-ogI4g9W5qIQQUhXAclq6zhqgqNUr7UlFaqDHbch7WLSLeeM/7d3CRaw7GLajxvyFvhJqw4Rpcz5bhoaYtIx6Tg==",
       "dev": true
     },
     "@types/node": {
@@ -3534,9 +3534,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
-      "integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -5760,27 +5760,32 @@
       }
     },
     "rollup-plugin-uglify": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-6.0.2.tgz",
-      "integrity": "sha512-qwz2Tryspn5QGtPUowq5oumKSxANKdrnfz7C0jm4lKxvRDsNe/hSGsB9FntUul7UeC4TsZEWKErVgE1qWSO0gw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-6.0.3.tgz",
+      "integrity": "sha512-PIv3CfhZJlOG8C85N0GX+uK09TPggmAS6Nk6fpp2ELzDAV5VUhNzOURDU2j7+MwuRr0zq9IZttUTADc/jH8Gkg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "jest-worker": "^24.0.0",
-        "serialize-javascript": "^1.6.1",
+        "serialize-javascript": "^1.9.0",
         "uglify-js": "^3.4.9"
       },
       "dependencies": {
         "jest-worker": {
-          "version": "24.4.0",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.4.0.tgz",
-          "integrity": "sha512-BH9X/klG9vxwoO99ZBUbZFfV8qO0XNZ5SIiCyYK2zOuJBl6YJVAeNIQjcoOVNu4HGEHeYEKsUWws8kSlSbZ9YQ==",
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
+          "integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
           "dev": true,
           "requires": {
-            "@types/node": "*",
-            "merge-stream": "^1.0.1",
+            "merge-stream": "^2.0.0",
             "supports-color": "^6.1.0"
           }
+        },
+        "merge-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+          "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+          "dev": true
         },
         "supports-color": {
           "version": "6.1.0",
@@ -6435,9 +6440,9 @@
       "dev": true
     },
     "serialize-javascript": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.6.1.tgz",
-      "integrity": "sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
+      "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
       "dev": true
     },
     "set-blocking": {

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
     "format": "prettier --write \"src/**/{*.ts,*.tsx}\""
   },
   "dependencies": {
-    "lodash": "4.17.13",
+    "lodash": "4.17.15",
     "winchan": "0.2.1"
   },
   "devDependencies": {
     "@types/jest": "23.3.1",
-    "@types/lodash": "4.14.132",
+    "@types/lodash": "4.14.144",
     "@types/webappsec-credential-management": "0.5.1",
     "jest": "23.6.0",
     "jest-fetch-mock": "1.6.6",
@@ -35,7 +35,7 @@
     "rollup-plugin-commonjs": "10.0.0",
     "rollup-plugin-node-resolve": "5.0.0",
     "rollup-plugin-typescript2": "0.21.1",
-    "rollup-plugin-uglify": "6.0.2",
+    "rollup-plugin-uglify": "6.0.3",
     "rollup-watch": "4.3.1",
     "prettier": "1.17.1",
     "ts-jest": "23.10.4",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -19,6 +19,7 @@ export interface Config {
 }
 
 export type Client = {
+  remoteSettings: Promise<RemoteSettings>
   on: <K extends keyof Events>(eventName: K, listener: (payload: Events[K]) => void) => void
   off: <K extends keyof Events>(eventName: K, listener: (payload: Events[K]) => void) => void
   signup: (params: SignupParams) => Promise<void>
@@ -61,9 +62,11 @@ export function createClient(creationConfig: Config): Client {
   const eventManager = createEventManager()
   const urlParser = createUrlParser(eventManager)
 
-  const apiClient = rawRequest<RemoteSettings>(
+  const remoteSettings = rawRequest<RemoteSettings>(
     `https://${domain}/identity/v1/config?${toQueryString({ clientId, lang: language })}`
-  ).then(
+  )
+
+  const apiClient = remoteSettings.then(
     remoteConfig =>
       new ApiClient({
         config: {
@@ -182,6 +185,7 @@ export function createClient(creationConfig: Config): Client {
   }
 
   return {
+    remoteSettings,
     on,
     off,
     signup,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -10,7 +10,7 @@ import { TokenRequestParameters } from './pkceService'
 
 export { AuthResult } from './authResult'
 export { AuthOptions } from './authOptions'
-export { Profile, SessionInfo } from './models'
+export { ErrorResponse, Profile, SessionInfo } from './models'
 
 export interface Config {
   clientId: string


### PR DESCRIPTION
I've made some changes to the SDK core for the SDK UI:
- I've exported the `remoteSettings` object to prevent a redundant call to get the account's settings from the server (SDK core is already doing the call).
- I've exported the `ErrorResponse` model since it's used by the `onError` error callback needed by some widgets.