### PR TITLE
Open a webview for social login if the Cordova platform is iOS

### DIFF
--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -226,18 +226,15 @@ export default class ApiClient {
 
       if (maybeBrowserTab) {
         maybeBrowserTab.openUrl(url, () => {}, logError)
-      }
-      else if (window.cordova.InAppBrowser) {
+      } else if (window.cordova.InAppBrowser) {
         if (window.cordova.platformId === 'ios') {
           // Open a webview (to pass Apple validation tests)
           window.cordova.InAppBrowser.open(url, '_blank')
-        }
-        else {
+        } else {
           // Open the system browser
           window.cordova.InAppBrowser.open(url, '_system')
         }
-      }
-      else {
+      } else {
         throw new Error('Cordova plugin "inappbrowser" is required.')
       }
     })

--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -226,9 +226,18 @@ export default class ApiClient {
 
       if (maybeBrowserTab) {
         maybeBrowserTab.openUrl(url, () => {}, logError)
-      } else if (window.cordova.InAppBrowser) {
-        window.cordova.InAppBrowser.open(url, '_system')
-      } else {
+      }
+      else if (window.cordova.InAppBrowser) {
+        if (window.cordova.platformId === 'ios') {
+          // Open a webview (to pass Apple validation tests)
+          window.cordova.InAppBrowser.open(url, '_blank')
+        }
+        else {
+          // Open the system browser
+          window.cordova.InAppBrowser.open(url, '_system')
+        }
+      }
+      else {
         throw new Error('Cordova plugin "inappbrowser" is required.')
       }
     })

--- a/src/main/global.d.ts
+++ b/src/main/global.d.ts
@@ -22,8 +22,9 @@ interface Window {
       browsertab?: BrowserTab
     }
     InAppBrowser?: {
-      open(url: string, target: '_self' | '_blank' | '_system'): void
-    }
-  }
+      open(url: string, target: '_self' | '_blank' | '_system') : void
+    },
+    platformId?: 'ios' | 'android'
+  } 
   handleOpenURL?: (url: string) => void
 }


### PR DESCRIPTION
To pass Apple application validation tests, the `loginWithSocialProvider` button must open a web view in the application and not Safari.