### PR TITLE
Release v0.1.0-alpha.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.0-alpha.21
+
+### 29/11/2019
+
+### Fixes
+- Open a webview for social login if the Cordova platform is iOS.
+
 ## 0.1.0-alpha.20
 
 ### 06/08/2019

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@reachfive/identity-core",
-  "version": "0.1.0-alpha.20",
+  "version": "0.1.0-alpha.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reachfive/identity-core",
-  "version": "0.1.0-alpha.20",
+  "version": "0.1.0-alpha.21",
   "license": "MIT",
   "main": "cjs/main.js",
   "module": "es/main.js",


### PR DESCRIPTION
- Update the changelog.
- Bump the version to `v0.1.0 alpha.21`.