### PR TITLE
Errors with PKCE methods for the UMD bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2442,6 +2442,11 @@
         }
       }
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -2546,6 +2551,15 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "buffer": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-from": {
@@ -4389,6 +4403,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "import-local": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "format": "prettier --write \"src/**/{*.ts,*.tsx}\""
   },
   "dependencies": {
+    "buffer": "5.4.3",
     "lodash": "4.17.15",
     "winchan": "0.2.2"
   },

--- a/src/main/pkceService.ts
+++ b/src/main/pkceService.ts
@@ -1,3 +1,5 @@
+import { Buffer } from 'buffer/'
+
 import { encodeToBase64 } from '../utils/base64'
 
 export type PkceParams = { codeChallenge: string; codeChallengeMethod: string }

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -1,3 +1,5 @@
+import { Buffer } from 'buffer/'
+
 /**
  * return an UTF-8 encoded string as URL Safe Base64
  *


### PR DESCRIPTION
I've installed the [`buffer`](https://www.npmjs.com/package/buffer) dependency to be able to use `Buffer` in the browser (and not only `node`).