### PR TITLE
Release v1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v.1.9.2
+
+### 02/12/2019
+
+### Fixes
+- Add the missing implementation of `Buffer` to address an issue with the UMD bundle when PKCE is enabled.
+
 ## v.1.9.1
 
 ### 29/11/2019

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@reachfive/identity-core",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reachfive/identity-core",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Reach5 Identity Web Core SDK",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
- Update the changelog.
- Bump version to `v1.9.2`.