### PR TITLE
Better checks for credentials management API support

### DIFF
--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -194,7 +194,7 @@ export default class ApiClient {
   }
 
   logout(opts: { redirectTo?: string; removeCredentials?: boolean } = {}): void {
-    if (navigator.credentials.preventSilentAccess && opts.removeCredentials === true) {
+    if (navigator.credentials && navigator.credentials.preventSilentAccess && opts.removeCredentials === true) {
       navigator.credentials.preventSilentAccess()
     }
     window.location.assign(`${this.baseUrl}/logout?${toQueryString(opts)}`)
@@ -318,7 +318,7 @@ export default class ApiClient {
   }
 
   private storeCredentials(params: LoginWithPasswordParams): Promise<void> {
-    if (navigator.credentials.create && navigator.credentials.store) {
+    if (navigator.credentials && navigator.credentials.create && navigator.credentials.store) {
       const credentialParams = {
         password: {
           password: params.password,
@@ -544,7 +544,7 @@ export default class ApiClient {
   }
 
   loginWithCredentials(params: LoginWithCredentialsParams): Promise<void> {
-    if (navigator.credentials.get) {
+    if (navigator.credentials && navigator.credentials.get) {
       const request: CredentialRequestOptions = {
         password: true,
         mediation: params.mediation || 'silent'


### PR DESCRIPTION
Related to [this ticket](https://app.asana.com/0/1142049698926411/1153200521179429)

Checks are in the form `if(navigator.credentials.preventSilentAccess)`, but older Safari and IE versions don't support the Credential Management API and `navigator.credentials` is completely absent.

This adds some checks to avoid trying to access a property of a null `credentials` object. 