### PR TITLE
Test the CircleCi 'deploy-release' job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
         command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
     - run:
         name: Publish package
-        command: npm publish
+        command: npm publish --dry-run
 
 workflows:
   version: 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@reachfive/identity-core",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reachfive/identity-core",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Reach5 Identity Web Core SDK",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
I've temporarily added the `-dry--run` option (https://docs.npmjs.com/cli/publish) to test the Circle ci `deploy-release` job.