### PR TITLE
Enable SDK users to obtain AuthResult using web messages instead of redirection

### DIFF
--- a/src/main/__tests__/apiClient.spec.ts
+++ b/src/main/__tests__/apiClient.spec.ts
@@ -91,9 +91,9 @@ describe('loginFromSession', () => {
         toQueryString({
           client_id: clientId,
           response_type: 'token',
+          id_token_hint: idTokenHint,
           scope: 'openid profile email phone',
           display: 'page',
-          id_token_hint: idTokenHint,
           prompt: 'none'
         })
     )
@@ -117,10 +117,10 @@ describe('loginFromSession', () => {
         toQueryString({
           client_id: clientId,
           response_type: 'code',
-          scope: 'openid profile email phone',
-          display: 'page',
           redirect_uri: redirectUri,
           id_token_hint: idTokenHint,
+          scope: 'openid profile email phone',
+          display: 'page',
           prompt: 'none'
         })
     )
@@ -178,9 +178,9 @@ describe('loginFromSession', () => {
         toQueryString({
           client_id: clientId,
           response_type: 'token',
+          id_token_hint: idTokenHint,
           scope: 'openid profile email phone',
           display: 'page',
-          id_token_hint: idTokenHint,
           prompt: 'none'
         })
     )

--- a/src/main/__tests__/apiClientCordova.spec.ts
+++ b/src/main/__tests__/apiClientCordova.spec.ts
@@ -738,9 +738,9 @@ describe('loginWithSocialProvider', () => {
         toQueryString({
           client_id: clientId,
           response_type: 'code',
+          redirect_uri: redirectUri,
           scope: 'openid profile email phone',
           display: 'page',
-          redirect_uri: redirectUri,
           provider: 'facebook'
         }),
       '_system'
@@ -773,9 +773,9 @@ describe('loginWithSocialProvider', () => {
         toQueryString({
           client_id: clientId,
           response_type: 'code',
+          redirect_uri: redirectUri,
           scope: 'openid profile email phone',
           display: 'page',
-          redirect_uri: redirectUri,
           provider: 'facebook'
         }),
       '_blank'

--- a/src/main/__tests__/authOptions.spec.ts
+++ b/src/main/__tests__/authOptions.spec.ts
@@ -2,15 +2,16 @@ import { computeAuthOptions } from '../authOptions'
 
 describe('computeAuthOptions', () => {
   test('responseType defaults', () => {
-    const expectedDefault = {
+    expect(computeAuthOptions()).toEqual({
+      display: 'page',
       responseType: 'token',
-      prompt: 'none',
-      responseMode: 'web_message',
       scope: 'openid profile email phone'
-    }
-
-    expect(computeAuthOptions()).toEqual(expectedDefault)
-    expect(computeAuthOptions({})).toEqual(expectedDefault)
+    })
+    expect(computeAuthOptions({})).toEqual({
+      display: 'page',
+      responseType: 'token',
+      scope: 'openid profile email phone'
+    })
   })
 
   test('with redirect uri', () => {
@@ -19,8 +20,7 @@ describe('computeAuthOptions', () => {
         redirectUri: 'https://localhost/login.callback'
       })
     ).toEqual({
-      prompt: 'none',
-      responseMode: 'web_message',
+      display: 'page',
       responseType: 'code',
       scope: 'openid profile email phone',
       redirectUri: 'https://localhost/login.callback'
@@ -29,8 +29,7 @@ describe('computeAuthOptions', () => {
 
   test('with extended scope', () => {
     const result = {
-      prompt: 'none',
-      responseMode: 'web_message',
+      display: 'page',
       responseType: 'token',
       scope: 'openid profile email phone address'
     }
@@ -48,8 +47,7 @@ describe('computeAuthOptions', () => {
 
   test('with specific scope', () => {
     const result = {
-      prompt: 'none',
-      responseMode: 'web_message',
+      display: 'page',
       responseType: 'token',
       scope: 'openid profile'
     }
@@ -77,9 +75,8 @@ describe('computeAuthOptions', () => {
 
   test('popup mode when refused', () => {
     expect(computeAuthOptions({ popupMode: true })).toEqual({
+      display: 'page',
       responseType: 'token',
-      prompt: 'none',
-      responseMode: 'web_message',
       scope: 'openid profile email phone'
     })
   })
@@ -90,8 +87,7 @@ describe('computeAuthOptions', () => {
         requireRefreshToken: true
       })
     ).toEqual({
-      prompt: 'none',
-      responseMode: 'web_message',
+      display: 'page',
       responseType: 'token',
       scope: 'openid profile email phone offline_access'
     })

--- a/src/main/__tests__/authOptions.spec.ts
+++ b/src/main/__tests__/authOptions.spec.ts
@@ -2,16 +2,15 @@ import { computeAuthOptions } from '../authOptions'
 
 describe('computeAuthOptions', () => {
   test('responseType defaults', () => {
-    expect(computeAuthOptions()).toEqual({
-      display: 'page',
+    const expectedDefault = {
       responseType: 'token',
+      prompt: 'none',
+      responseMode: 'web_message',
       scope: 'openid profile email phone'
-    })
-    expect(computeAuthOptions({})).toEqual({
-      display: 'page',
-      responseType: 'token',
-      scope: 'openid profile email phone'
-    })
+    }
+
+    expect(computeAuthOptions()).toEqual(expectedDefault)
+    expect(computeAuthOptions({})).toEqual(expectedDefault)
   })
 
   test('with redirect uri', () => {
@@ -20,7 +19,8 @@ describe('computeAuthOptions', () => {
         redirectUri: 'https://localhost/login.callback'
       })
     ).toEqual({
-      display: 'page',
+      prompt: 'none',
+      responseMode: 'web_message',
       responseType: 'code',
       scope: 'openid profile email phone',
       redirectUri: 'https://localhost/login.callback'
@@ -29,7 +29,8 @@ describe('computeAuthOptions', () => {
 
   test('with extended scope', () => {
     const result = {
-      display: 'page',
+      prompt: 'none',
+      responseMode: 'web_message',
       responseType: 'token',
       scope: 'openid profile email phone address'
     }
@@ -47,7 +48,8 @@ describe('computeAuthOptions', () => {
 
   test('with specific scope', () => {
     const result = {
-      display: 'page',
+      prompt: 'none',
+      responseMode: 'web_message',
       responseType: 'token',
       scope: 'openid profile'
     }
@@ -75,8 +77,9 @@ describe('computeAuthOptions', () => {
 
   test('popup mode when refused', () => {
     expect(computeAuthOptions({ popupMode: true })).toEqual({
-      display: 'page',
       responseType: 'token',
+      prompt: 'none',
+      responseMode: 'web_message',
       scope: 'openid profile email phone'
     })
   })
@@ -87,7 +90,8 @@ describe('computeAuthOptions', () => {
         requireRefreshToken: true
       })
     ).toEqual({
-      display: 'page',
+      prompt: 'none',
+      responseMode: 'web_message',
       responseType: 'token',
       scope: 'openid profile email phone offline_access'
     })

--- a/src/main/__tests__/checkSession.spec.ts
+++ b/src/main/__tests__/checkSession.spec.ts
@@ -31,7 +31,6 @@ describe('checkSession', () => {
             client_id: clientId,
             response_type: 'token',
             scope: 'openid profile email phone',
-            display: 'page',
             response_mode: 'web_message',
             prompt: 'none'
           })
@@ -61,9 +60,8 @@ describe('checkSession', () => {
           toQueryString({
             client_id: clientId,
             response_type: 'token',
-            scope: 'openid profile email phone',
-            display: 'page',
             nonce,
+            scope: 'openid profile email phone',
             response_mode: 'web_message',
             prompt: 'none'
           })

--- a/src/main/__tests__/checkSession.spec.ts
+++ b/src/main/__tests__/checkSession.spec.ts
@@ -1,7 +1,5 @@
 import fetchMock from 'jest-fetch-mock'
-import { createDefaultTestClient } from './testHelpers'
-import { toQueryString } from '../../utils/queryString'
-import { delay } from '../../utils/promise'
+import { createDefaultTestClient, expectIframeWithParams } from './testHelpers'
 
 beforeEach(() => {
   window.fetch = fetchMock
@@ -11,61 +9,35 @@ beforeEach(() => {
 
 describe('checkSession', () => {
   test('basic', async () => {
-    const { api, domain, clientId } = createDefaultTestClient({ sso: true })
+    const { api, domain, clientId } = createDefaultTestClient({sso: true})
 
     api.checkSession().catch(err => console.log(err))
 
-    await delay(10)
-
-    const iframe = document.querySelector('iframe')
-
-    expect(iframe).not.toBeNull()
-
-    if (iframe) {
-      // Make Typescript happy
-      expect(iframe.getAttribute('height')).toEqual('0')
-      expect(iframe.getAttribute('width')).toEqual('0')
-      expect(iframe.getAttribute('src')).toEqual(
-        `https://${domain}/oauth/authorize?` +
-          toQueryString({
-            client_id: clientId,
-            response_type: 'token',
-            scope: 'openid profile email phone',
-            response_mode: 'web_message',
-            prompt: 'none'
-          })
-      )
-    }
+    await expectIframeWithParams(domain, {
+      client_id: clientId,
+      response_type: 'token',
+      scope: 'openid profile email phone',
+      response_mode: 'web_message',
+      prompt: 'none'
+    })
   })
 
   test('with nonce', async () => {
-    const { api, domain, clientId } = createDefaultTestClient({ sso: true })
+    const { api, domain, clientId } = createDefaultTestClient({sso: true})
 
     const nonce = 'pizjfoihzefoiaef'
 
-    api.checkSession({ nonce }).catch(err => console.log(err))
+    api.checkSession({
+      nonce
+    }).catch(err => console.log(err))
 
-    await delay(10)
-
-    const iframe = document.querySelector('iframe')
-
-    expect(iframe).not.toBeNull()
-
-    if (iframe) {
-      // Make Typescript happy
-      expect(iframe.getAttribute('height')).toEqual('0')
-      expect(iframe.getAttribute('width')).toEqual('0')
-      expect(iframe.getAttribute('src')).toEqual(
-        `https://${domain}/oauth/authorize?` +
-          toQueryString({
-            client_id: clientId,
-            response_type: 'token',
-            nonce,
-            scope: 'openid profile email phone',
-            response_mode: 'web_message',
-            prompt: 'none'
-          })
-      )
-    }
+    await expectIframeWithParams(domain, {
+      client_id: clientId,
+      response_type: 'token',
+      nonce,
+      scope: 'openid profile email phone',
+      response_mode: 'web_message',
+      prompt: 'none'
+    })
   })
 })

--- a/src/main/__tests__/checkSession.spec.ts
+++ b/src/main/__tests__/checkSession.spec.ts
@@ -9,7 +9,7 @@ beforeEach(() => {
 
 describe('checkSession', () => {
   test('basic', async () => {
-    const { api, domain, clientId } = createDefaultTestClient({sso: true})
+    const { api, domain, clientId } = createDefaultTestClient({ sso: true })
 
     api.checkSession().catch(err => console.log(err))
 
@@ -23,7 +23,7 @@ describe('checkSession', () => {
   })
 
   test('with nonce', async () => {
-    const { api, domain, clientId } = createDefaultTestClient({sso: true})
+    const { api, domain, clientId } = createDefaultTestClient({ sso: true })
 
     const nonce = 'pizjfoihzefoiaef'
 

--- a/src/main/__tests__/loginFromSession.spec.ts
+++ b/src/main/__tests__/loginFromSession.spec.ts
@@ -19,9 +19,9 @@ test('loginFromSession', async () => {
       toQueryString({
         client_id: clientId,
         response_type: 'code',
+        redirect_uri: redirectUri,
         scope: 'openid profile email phone',
         display: 'page',
-        redirect_uri: redirectUri,
         prompt: 'none'
       })
   )

--- a/src/main/__tests__/loginWithPassword.spec.ts
+++ b/src/main/__tests__/loginWithPassword.spec.ts
@@ -22,7 +22,13 @@ test('with default auth config (email/password)', async () => {
 
   // When
   let error = null
-  api.loginWithPassword({ email, password }).catch(err => (error = err))
+  api.loginWithPassword({
+    email,
+    password,
+    auth: {
+      useRedirect: true
+    }
+  }).catch(err => (error = err))
 
   await delay(1)
 
@@ -59,7 +65,13 @@ test('with default auth config (phone/password)', async () => {
 
   // When
   let error = null
-  api.loginWithPassword({ phoneNumber, password }).catch(err => (error = err))
+  api.loginWithPassword({
+    phoneNumber,
+    password,
+    auth: {
+      useRedirect: true
+    }
+  }).catch(err => (error = err))
 
   await delay(1)
 
@@ -105,7 +117,8 @@ test('with popup mode (email/password)', async () => {
       password,
       auth: {
         redirectUri,
-        popupMode: true
+        popupMode: true,
+        useRedirect: true
       }
     })
     .catch(err => (error = err))
@@ -119,9 +132,10 @@ test('with popup mode (email/password)', async () => {
       toQueryString({
         client_id: clientId,
         response_type: 'code',
-        scope: defaultScope,
-        display: 'page',
         redirect_uri: redirectUri,
+        scope: defaultScope,
+        // popupMode is intentionally ignored
+        display: 'page',
         tkn: passwordToken
       })
   )
@@ -145,6 +159,7 @@ test('with default auth (email/password)', async () => {
       email,
       password,
       auth: {
+        useRedirect: true,
         fetchBasicProfile: false,
         scope: ['openid', 'email']
       }

--- a/src/main/__tests__/loginWithSocialProvider.spec.ts
+++ b/src/main/__tests__/loginWithSocialProvider.spec.ts
@@ -13,7 +13,7 @@ test('with default auth', async () => {
   const { api, clientId, domain } = createDefaultTestClient()
 
   let error = null
-  api.loginWithSocialProvider('google', {}).catch(err => (error = err))
+  api.loginWithSocialProvider('google', { useRedirect: true }).catch(err => (error = err))
 
   await delay(1)
 
@@ -47,9 +47,9 @@ test('with auth params', async () => {
       toQueryString({
         client_id: clientId,
         response_type: 'code',
+        redirect_uri: redirectUri,
         scope: 'openid profile email phone',
         display: 'page',
-        redirect_uri: redirectUri,
         provider: 'linkedin'
       })
   )
@@ -74,9 +74,9 @@ test('with access token auth param', async () => {
       toQueryString({
         client_id: clientId,
         response_type: 'token',
+        access_token: accessToken,
         scope: 'openid profile email phone',
         display: 'page',
-        access_token: accessToken,
         provider: 'paypal'
       })
   )

--- a/src/main/__tests__/loginWithSocialProvider.spec.ts
+++ b/src/main/__tests__/loginWithSocialProvider.spec.ts
@@ -13,7 +13,7 @@ test('with default auth', async () => {
   const { api, clientId, domain } = createDefaultTestClient()
 
   let error = null
-  api.loginWithSocialProvider('google', { useRedirect: true }).catch(err => (error = err))
+  api.loginWithSocialProvider('google', {}).catch(err => (error = err))
 
   await delay(1)
 

--- a/src/main/__tests__/signup.spec.ts
+++ b/src/main/__tests__/signup.spec.ts
@@ -33,9 +33,6 @@ test('with default auth (using redirect)', async () => {
         familyName: 'Doe',
         email: 'john.doe@example.com',
         password: 'P@ssw0rd'
-      },
-      auth: {
-        useRedirect: true
       }
     })
     .catch(err => (error = err))
@@ -94,6 +91,9 @@ test('with default auth (using web_message)', async () => {
         familyName: 'Doe',
         email: 'john.doe@example.com',
         password: 'P@ssw0rd'
+      },
+      auth: {
+        useWebMessage: true
       }
     })
     .catch(err => (error = err))
@@ -151,7 +151,6 @@ test('with auth param', async () => {
         password: 'P@ssw0rd'
       },
       auth: {
-        useRedirect: true,
         redirectUri
       }
     })
@@ -210,7 +209,6 @@ test('popup mode ignored', async () => {
         password: 'P@ssw0rd'
       },
       auth: {
-        useRedirect: true,
         popupMode: true
       }
     })

--- a/src/main/__tests__/signup.spec.ts
+++ b/src/main/__tests__/signup.spec.ts
@@ -10,7 +10,7 @@ beforeEach(() => {
 
 const defaultScope = 'openid profile email phone'
 
-test('with default auth', async () => {
+test('with default auth (using redirect)', async () => {
   // Given
   const { api, clientId, domain } = createDefaultTestClient()
 
@@ -33,6 +33,9 @@ test('with default auth', async () => {
         familyName: 'Doe',
         email: 'john.doe@example.com',
         password: 'P@ssw0rd'
+      },
+      auth: {
+        useRedirect: true
       }
     })
     .catch(err => (error = err))
@@ -68,6 +71,65 @@ test('with default auth', async () => {
   )
 })
 
+// TODO/cbu
+// test('with default auth (using web_message)', async () => {
+//   // Given
+//   const { api, clientId, domain } = createDefaultTestClient()
+//
+//   const signupToken = 'signupToken'
+//
+//   const fetch1 = fetchMock.mockResponseOnce(
+//     JSON.stringify({
+//       id: '1234',
+//       tkn: signupToken
+//     })
+//   )
+//
+//   let error = null
+//
+//   // When
+//   api
+//     .signup({
+//       data: {
+//         givenName: 'John',
+//         familyName: 'Doe',
+//         email: 'john.doe@example.com',
+//         password: 'P@ssw0rd'
+//       }
+//     })
+//     .catch(err => (error = err))
+//
+//   await delay(20)
+//
+//   // Then
+//
+//   expect(error).toBeNull()
+//   expect(fetch1).toHaveBeenCalledWith(`https://${domain}/identity/v1/signup`, {
+//     method: 'POST',
+//     headers: headers.jsonAndDefaultLang,
+//     body: JSON.stringify({
+//       client_id: clientId,
+//       scope: defaultScope,
+//       data: {
+//         given_name: 'John',
+//         family_name: 'Doe',
+//         email: 'john.doe@example.com',
+//         password: 'P@ssw0rd'
+//       }
+//     })
+//   })
+//   expect(window.location.assign).toHaveBeenCalledWith(
+//     `https://${domain}/oauth/authorize?` +
+//       toQueryString({
+//         client_id: clientId,
+//         response_type: 'token',
+//         scope: defaultScope,
+//         display: 'page',
+//         tkn: signupToken
+//       })
+//   )
+// })
+
 test('with auth param', async () => {
   // Given
   const { api, clientId, domain } = createDefaultTestClient()
@@ -91,6 +153,7 @@ test('with auth param', async () => {
         password: 'P@ssw0rd'
       },
       auth: {
+        useRedirect: true,
         redirectUri
       }
     })
@@ -117,9 +180,9 @@ test('with auth param', async () => {
       toQueryString({
         client_id: clientId,
         response_type: 'code',
+        redirect_uri: redirectUri,
         scope: defaultScope,
         display: 'page',
-        redirect_uri: redirectUri,
         tkn: signupToken
       })
   )
@@ -149,6 +212,7 @@ test('popup mode ignored', async () => {
         password: 'P@ssw0rd'
       },
       auth: {
+        useRedirect: true,
         popupMode: true
       }
     })

--- a/src/main/__tests__/signup.spec.ts
+++ b/src/main/__tests__/signup.spec.ts
@@ -1,7 +1,7 @@
 import fetchMock from 'jest-fetch-mock'
 import { delay } from '../../utils/promise'
 import { toQueryString } from '../../utils/queryString'
-import { createDefaultTestClient, headers } from './testHelpers'
+import { createDefaultTestClient, expectIframeWithParams, headers } from './testHelpers'
 
 beforeEach(() => {
   window.fetch = fetchMock
@@ -71,64 +71,62 @@ test('with default auth (using redirect)', async () => {
   )
 })
 
-// TODO/cbu
-// test('with default auth (using web_message)', async () => {
-//   // Given
-//   const { api, clientId, domain } = createDefaultTestClient()
-//
-//   const signupToken = 'signupToken'
-//
-//   const fetch1 = fetchMock.mockResponseOnce(
-//     JSON.stringify({
-//       id: '1234',
-//       tkn: signupToken
-//     })
-//   )
-//
-//   let error = null
-//
-//   // When
-//   api
-//     .signup({
-//       data: {
-//         givenName: 'John',
-//         familyName: 'Doe',
-//         email: 'john.doe@example.com',
-//         password: 'P@ssw0rd'
-//       }
-//     })
-//     .catch(err => (error = err))
-//
-//   await delay(20)
-//
-//   // Then
-//
-//   expect(error).toBeNull()
-//   expect(fetch1).toHaveBeenCalledWith(`https://${domain}/identity/v1/signup`, {
-//     method: 'POST',
-//     headers: headers.jsonAndDefaultLang,
-//     body: JSON.stringify({
-//       client_id: clientId,
-//       scope: defaultScope,
-//       data: {
-//         given_name: 'John',
-//         family_name: 'Doe',
-//         email: 'john.doe@example.com',
-//         password: 'P@ssw0rd'
-//       }
-//     })
-//   })
-//   expect(window.location.assign).toHaveBeenCalledWith(
-//     `https://${domain}/oauth/authorize?` +
-//       toQueryString({
-//         client_id: clientId,
-//         response_type: 'token',
-//         scope: defaultScope,
-//         display: 'page',
-//         tkn: signupToken
-//       })
-//   )
-// })
+test('with default auth (using web_message)', async () => {
+  // Given
+  const { api, clientId, domain } = createDefaultTestClient()
+
+  const signupToken = 'signupToken'
+
+  const fetch1 = fetchMock.mockResponseOnce(
+    JSON.stringify({
+      id: '1234',
+      tkn: signupToken
+    })
+  )
+
+  let error = null
+
+  // When
+  api
+    .signup({
+      data: {
+        givenName: 'John',
+        familyName: 'Doe',
+        email: 'john.doe@example.com',
+        password: 'P@ssw0rd'
+      }
+    })
+    .catch(err => (error = err))
+
+  await delay(20)
+
+  // Then
+
+  expect(error).toBeNull()
+  expect(fetch1).toHaveBeenCalledWith(`https://${domain}/identity/v1/signup`, {
+    method: 'POST',
+    headers: headers.jsonAndDefaultLang,
+    body: JSON.stringify({
+      client_id: clientId,
+      scope: defaultScope,
+      data: {
+        given_name: 'John',
+        family_name: 'Doe',
+        email: 'john.doe@example.com',
+        password: 'P@ssw0rd'
+      }
+    })
+  })
+
+  await expectIframeWithParams(domain, {
+    client_id: clientId,
+    response_type: 'token',
+    scope: defaultScope,
+    responseMode: 'web_message',
+    prompt: 'none',
+    tkn: signupToken
+  })
+})
 
 test('with auth param', async () => {
   // Given

--- a/src/main/__tests__/testHelpers.ts
+++ b/src/main/__tests__/testHelpers.ts
@@ -1,6 +1,8 @@
 import fetchMock from 'jest-fetch-mock'
 import { Config, createClient } from '../main'
 import { RemoteSettings } from '../models'
+import { toQueryString } from '../../utils/queryString'
+import { delay } from '../../utils/promise'
 
 export function createDefaultTestClient(remoteSettings: Partial<RemoteSettings> = {}) {
   const actualRemoteSettings = {
@@ -48,4 +50,21 @@ export const headers = {
     ...jsonHeader,
     ...defaultLangHeader
   }
+}
+
+export async function expectIframeWithParams(
+  domain: string,
+  params: {}
+) {
+  await delay(15)
+  const iframe = document.querySelector('iframe')
+  expect(iframe).not.toBeNull()
+  if (iframe) {
+    // Make Typescript happy
+    expect(iframe.getAttribute('height')).toEqual('0')
+    expect(iframe.getAttribute('width')).toEqual('0')
+    expect(iframe.getAttribute('src')).toEqual(
+      `https://${domain}/oauth/authorize?${toQueryString(params)}`
+    )
+  } else fail('No iframe found!')
 }

--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -149,7 +149,7 @@ export default class ApiClient {
   loginWithSocialProvider(provider: string, opts: AuthOptions = {}): Promise<void> {
     const authParams = this.authParams({
       ...opts,
-      useRedirect: true
+      useWebMessage: false
     }, { acceptPopupMode: true })
 
     return this.getPkceParams(authParams).then(maybeChallenge => {
@@ -195,7 +195,7 @@ export default class ApiClient {
     return this.loginWithRedirect({
       ...this.authParams({
         ...opts,
-        useRedirect: true
+        useWebMessage: false
       }),
       prompt: 'none'
     })
@@ -209,9 +209,10 @@ export default class ApiClient {
     }
 
     const authorizationUrl = this.getAuthorizationUrl({
-      ...this.authParams(opts),
-      responseMode: 'web_message',
-      prompt: 'none'
+      ...this.authParams({
+        ...opts,
+        useWebMessage: true
+      })
     })
 
     return this.getWebMessage(
@@ -470,14 +471,14 @@ export default class ApiClient {
         ...pick(tkn, 'tkn')
       })
 
-      if (auth.useRedirect) {
-        return redirect(`${this.authorizeUrl}?${queryString}`)
-      } else {
+      if (auth.useWebMessage) {
         return this.getWebMessage(
           `${this.authorizeUrl}?${queryString}`,
           `https://${this.config.domain}`,
           auth.redirectUri || ""
         ) as Promise<AuthResult | void>
+      } else {
+        return redirect(`${this.authorizeUrl}?${queryString}`)
       }
     })
   }

--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -409,7 +409,7 @@ export default class ApiClient {
               }
             })
             .then(tkn => this.storeCredentialsInBrowser(params).then(() => tkn))
-            .then(({ tkn }) => this.loginCallback(tkn, auth))
+            .then(tkn => this.loginCallback(tkn, auth))
 
     return (loginPromise as Promise<AuthResult | void>).catch((err: any) => {
       if (err.error) {
@@ -460,14 +460,14 @@ export default class ApiClient {
       .then(result => this.eventManager.fireEvent('authenticated', result))
   }
 
-  private loginCallback(tkn: string, auth: AuthOptions = {}): Promise<AuthResult | void> {
+  private loginCallback(tkn: AuthenticationToken, auth: AuthOptions = {}): Promise<AuthResult | void> {
     const authParams = this.authParams(auth)
 
     return this.getPkceParams(authParams).then(maybeChallenge => {
       const queryString = toQueryString({
         ...authParams,
         ...maybeChallenge,
-        tkn
+        ...tkn
       })
 
       if (auth.useRedirect) {
@@ -550,7 +550,7 @@ export default class ApiClient {
             }
           })
           .then(tkn => this.storeCredentialsInBrowser(loginParams).then(() => tkn))
-          .then(({ tkn }) => this.loginCallback(tkn, auth))
+          .then(tkn => this.loginCallback(tkn, auth))
 
     return (resultPromise as Promise<AuthResult | void>).catch(err => {
       if (err.error) {
@@ -733,7 +733,7 @@ export default class ApiClient {
 
             return this.http
               .post<AuthenticationToken>('/webauthn/authentication', { body: { ...serializedCredentials } })
-              .then(response => this.loginCallback(response.tkn, params.auth))
+              .then(tkn => this.loginCallback(tkn, params.auth))
         })
         .catch(err => {
           if (err.error) this.eventManager.fireEvent('login_failed', err)

--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -467,7 +467,7 @@ export default class ApiClient {
       const queryString = toQueryString({
         ...authParams,
         ...maybeChallenge,
-        ...tkn
+        ...pick(tkn, 'tkn')
       })
 
       if (auth.useRedirect) {

--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -516,6 +516,8 @@ export default class ApiClient {
 
   signup(params: SignupParams): Promise<AuthResult | void> {
     const { data, auth, redirectUrl, returnToAfterEmailConfirmation, saveCredentials } = params
+    const { clientId } = this.config
+    const scope = this.resolveScope(auth)
 
     const loginParams: LoginWithPasswordParams = {
       ...(data.phoneNumber)
@@ -530,9 +532,9 @@ export default class ApiClient {
       ? this.http
           .post<AuthResult>(`${this.baseUrl}/signup-token`, {
             body: {
-              clientId: this.config.clientId,
+              clientId,
               redirectUrl,
-              scope: this.resolveScope(auth),
+              scope,
               ...pick(auth, 'origin'),
               data,
               returnToAfterEmailConfirmation,
@@ -543,9 +545,9 @@ export default class ApiClient {
       : this.http
           .post<AuthenticationToken>('/signup', {
             body: {
-              clientId: this.config.clientId,
+              clientId,
               redirectUrl,
-              scope: this.resolveScope(auth),
+              scope,
               data,
               returnToAfterEmailConfirmation,
             }

--- a/src/main/authOptions.ts
+++ b/src/main/authOptions.ts
@@ -5,6 +5,7 @@ import isArray from 'lodash/isArray'
 import isUndefined from 'lodash/isUndefined'
 
 export type ResponseType = 'code' | 'token'
+export type Prompt = 'none' | 'login' | 'consent' | 'select_account'
 
 /**
  * More infos here: https://developer.reach5.co/api/identity-web-legacy/#authentication-options
@@ -14,8 +15,9 @@ export interface AuthOptions {
   redirectUri?: string
   scope?: string | string[]
   fetchBasicProfile?: boolean
+  useRedirect?: boolean
   popupMode?: boolean
-  prompt?: string
+  prompt?: Prompt
   origin?: string
   state?: string
   nonce?: string
@@ -27,15 +29,19 @@ export interface AuthOptions {
   persistent?: boolean
 }
 
+type ResponseMode = 'web_message'
+type Display = 'page' | 'popup' | 'touch' | 'wap'
+
 /**
  * This type represents the parameters that are actually sent to the HTTP API
  */
 export type AuthParameters = {
   responseType: ResponseType
+  responseMode?: ResponseMode
   scope: string
-  display: string
+  display?: Display
   redirectUri?: string
-  prompt?: string
+  prompt?: Prompt
   origin?: string
   state?: string
   nonce?: string
@@ -71,10 +77,15 @@ export function computeAuthOptions(
   { acceptPopupMode = false }: { acceptPopupMode?: boolean } = {},
   defaultScopes?: string
 ): AuthParameters {
+  const isPopup = opts.popupMode && acceptPopupMode
+  const responseType = opts.redirectUri ? 'code' : 'token'
+  const responseMode = isPopup || opts.useRedirect ? undefined : 'web_message'
+  const display = isPopup ? 'popup' : (responseMode !== 'web_message') ? 'page' : undefined
+  const prompt = responseMode === 'web_message' ? 'none' : opts.prompt
+  const scope = resolveScope(opts, defaultScopes)
+
   return {
-    responseType: opts.redirectUri ? 'code' : 'token',
-    scope: resolveScope(opts, defaultScopes),
-    display: opts.popupMode && acceptPopupMode ? 'popup' : 'page',
+    responseType,
     ...pick(opts, [
       'responseType',
       'redirectUri',
@@ -87,7 +98,11 @@ export function computeAuthOptions(
       'loginHint',
       'accessToken',
       'persistent'
-    ])
+    ]),
+    scope,
+    display,
+    responseMode,
+    prompt
   }
 }
 

--- a/src/main/authOptions.ts
+++ b/src/main/authOptions.ts
@@ -15,7 +15,7 @@ export interface AuthOptions {
   redirectUri?: string
   scope?: string | string[]
   fetchBasicProfile?: boolean
-  useRedirect?: boolean
+  useWebMessage?: boolean
   popupMode?: boolean
   prompt?: Prompt
   origin?: string
@@ -79,7 +79,7 @@ export function computeAuthOptions(
 ): AuthParameters {
   const isPopup = opts.popupMode && acceptPopupMode
   const responseType = opts.redirectUri ? 'code' : 'token'
-  const responseMode = isPopup || opts.useRedirect ? undefined : 'web_message'
+  const responseMode = opts.useWebMessage && !isPopup ? 'web_message': undefined
   const display = isPopup ? 'popup' : (responseMode !== 'web_message') ? 'page' : undefined
   const prompt = responseMode === 'web_message' ? 'none' : opts.prompt
   const scope = resolveScope(opts, defaultScopes)

--- a/src/main/authResult.ts
+++ b/src/main/authResult.ts
@@ -25,7 +25,7 @@ export function enrichAuthResult(response: AuthResult): AuthResult {
         idTokenPayload
       }
     } catch (e) {
-      logError('id token parsing error: ' + e)
+      logError("ID Token parsing error", e)
     }
   }
   return response
@@ -33,6 +33,6 @@ export function enrichAuthResult(response: AuthResult): AuthResult {
 
 export namespace AuthResult {
   export function isAuthResult(thing: any): thing is AuthResult {
-    return thing && (thing.accessToken || thing.idToken)
+    return thing && (thing.accessToken || thing.idToken || thing.code)
   }
 }

--- a/src/main/global.d.ts
+++ b/src/main/global.d.ts
@@ -1,5 +1,3 @@
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
-
 declare module 'winchan' {
   type Winchan = {
     open: any
@@ -22,9 +20,9 @@ interface Window {
       browsertab?: BrowserTab
     }
     InAppBrowser?: {
-      open(url: string, target: '_self' | '_blank' | '_system') : void
+      open(url: string, target: '_self' | '_blank' | '_system'): void
     },
     platformId?: 'ios' | 'android'
-  } 
+  }
   handleOpenURL?: (url: string) => void
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -36,15 +36,15 @@ export type Client = {
   remoteSettings: Promise<RemoteSettings>
   on: <K extends keyof Events>(eventName: K, listener: (payload: Events[K]) => void) => void
   off: <K extends keyof Events>(eventName: K, listener: (payload: Events[K]) => void) => void
-  signup: (params: SignupParams) => Promise<void>
+  signup: (params: SignupParams) => Promise<AuthResult | void>
   getSignupData: (signupToken: string) => Promise<OpenIdUser>
-  loginWithPassword: (params: LoginWithPasswordParams) => Promise<void>
+  loginWithPassword: (params: LoginWithPasswordParams) => Promise<AuthResult | void>
   sendEmailVerification: (params: EmailVerificationParams) => Promise<void>
   sendPhoneNumberVerification: (params: PhoneNumberVerificationParams) => Promise<void>
   startPasswordless: (params: PasswordlessParams, options?: AuthOptions) => Promise<void>
   verifyPasswordless: (params: VerifyPasswordlessParams) => Promise<void>
   loginWithSocialProvider: (provider: string, options?: AuthOptions) => Promise<void>
-  exchangeAuthorizationCodeWithPkce: (params: TokenRequestParameters) => Promise<void>
+  exchangeAuthorizationCodeWithPkce: (params: TokenRequestParameters) => Promise<AuthResult>
   requestPasswordReset: (params: RequestPasswordResetParams) => Promise<void>
   unlink: (params: { accessToken: string; identityId: string; fields?: string }) => Promise<void>
   refreshTokens: (params: { accessToken: string }) => Promise<AuthResult>
@@ -60,7 +60,7 @@ export type Client = {
   loginWithCustomToken: (params: { token: string; auth: AuthOptions }) => Promise<void>
   loginWithCredentials: (params: LoginWithCredentialsParams) => Promise<void>
   addNewWebAuthnDevice: (accessToken: string, friendlyName?: string) => Promise<void>
-  loginWithWebAuthn: (params: LoginWithWebAuthnParams) => Promise<void>
+  loginWithWebAuthn: (params: LoginWithWebAuthnParams) => Promise<AuthResult | void>
   listWebAuthnDevices: (accessToken: string) => Promise<DeviceCredential[]>
   removeWebAuthnDevice: (accessToken: string, deviceId: string) => Promise<void>
   getSessionInfo: (params?: {}) => Promise<SessionInfo>

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -36,9 +36,9 @@ export type Client = {
   remoteSettings: Promise<RemoteSettings>
   on: <K extends keyof Events>(eventName: K, listener: (payload: Events[K]) => void) => void
   off: <K extends keyof Events>(eventName: K, listener: (payload: Events[K]) => void) => void
-  signup: (params: SignupParams) => Promise<AuthResult | void>
+  signup: (params: SignupParams) => Promise<AuthResult>
   getSignupData: (signupToken: string) => Promise<OpenIdUser>
-  loginWithPassword: (params: LoginWithPasswordParams) => Promise<AuthResult | void>
+  loginWithPassword: (params: LoginWithPasswordParams) => Promise<AuthResult>
   sendEmailVerification: (params: EmailVerificationParams) => Promise<void>
   sendPhoneNumberVerification: (params: PhoneNumberVerificationParams) => Promise<void>
   startPasswordless: (params: PasswordlessParams, options?: AuthOptions) => Promise<void>
@@ -58,9 +58,9 @@ export type Client = {
   updatePhoneNumber: (params: { accessToken: string; phoneNumber: string }) => Promise<void>
   verifyPhoneNumber: (params: { accessToken: string; phoneNumber: string; verificationCode: string }) => Promise<void>
   loginWithCustomToken: (params: { token: string; auth: AuthOptions }) => Promise<void>
-  loginWithCredentials: (params: LoginWithCredentialsParams) => Promise<void>
+  loginWithCredentials: (params: LoginWithCredentialsParams) => Promise<AuthResult>
   addNewWebAuthnDevice: (accessToken: string, friendlyName?: string) => Promise<void>
-  loginWithWebAuthn: (params: LoginWithWebAuthnParams) => Promise<AuthResult | void>
+  loginWithWebAuthn: (params: LoginWithWebAuthnParams) => Promise<AuthResult>
   listWebAuthnDevices: (accessToken: string) => Promise<DeviceCredential[]>
   removeWebAuthnDevice: (accessToken: string, deviceId: string) => Promise<void>
   getSessionInfo: (params?: {}) => Promise<SessionInfo>

--- a/src/utils/queryString.ts
+++ b/src/utils/queryString.ts
@@ -24,7 +24,7 @@ export function parseQueryString(queryString: string): Record<string, string | u
   return camelCaseProperties(qs) as Record<string, string | undefined>
 }
 
-export function toQueryString(obj: QueryString, snakeCase = true) {
+export function toQueryString(obj: QueryString, snakeCase = true): string {
   const params = snakeCase ? snakeCaseProperties(obj) : obj
   return map(pickBy(params, v => v !== null && v !== undefined), (value, key) =>
     value !== '' ? `${key}=${encodeURIComponent(value)}` : key


### PR DESCRIPTION
It is now possible to perform signup, password and Webauthn flows in a "redirectionless" fashion. This is done by using the [web_message](https://tools.ietf.org/html/draft-sakimura-oauth-wmrm-00) `response_mode`. The web_message flow uses a hidden iframe using the code flow with PKCE flow for increased security. This means that user-agents are no longer required to perform a redirection to obtain authorization codes!

To try out this new feature, toggle `AuthOptions.useWebMessage` to `true` and let the magic happen. The relevant client API methods have been updated to return a much more convenient type: `Promise<AuthOptions>`.

# Changes

* task: add a new `AuthOptions` parameter `useWebMessage` to leverage web messages and redirectionless auth
* refactor:`signup`: now returns `Promise<AuthResult>`
* refactor: `loginWithPassword` now returns `Promise<AuthResult>`
* refactor: `loginWithCredentials` now returns `Promise<AuthResult>`
* refactor: `exchangeAuthorizationCodeWithPkce` now returns `Promise<AuthResult>`
* refactor: `loginWithWebAuthn` now returns `Promise<AuthResult>`
* refactor: make `computeProviderPopupOptions` static
* refactor: make promise error handling consistent across ApiClient.ts
* refactor: make `AuthOptions.prompt` a string union (type `Prompt`)
* refactor: make `AuthParameters.display` a string union (type `Display`)
* refactor: make `AuthParameters.responseMode` a string union (type `ResponseMode`)
* refactor: improve parameter resolving logic in `computeAuthOptions` to better handle `scope`, `display`, `responseMode` and `prompt` arguments
* chore: rename `loginWithPasswordByOAuth` => `ropcPasswordLogin`
* chore: rename `loginWithAuthenticationCallback` => `loginCallback`