### PR TITLE
Revert "Ajout d'un paramètre purpose lors du reset password."

### DIFF
--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -68,7 +68,6 @@ type EmailVerificationCodeUpdatePasswordParams = {
   email: string
   verificationCode: string
   password: string
-  purpose: string
 }
 
 type SmsVerificationCodeUpdatePasswordParams = {


### PR DESCRIPTION
Reverts ReachFive/identity-web-core-sdk#111

The proposed solution adds a new mandatory parameter which breaks compatibility.