### PR TITLE
Use the env variables in the CircleCi "reachfive" context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,7 @@ workflows:
             tags:
               only: /.*/
       - deploy-alpha:
+          context: reachfive
           requires:
             - test
           filters:
@@ -72,6 +73,7 @@ workflows:
             branches:
               ignore: /.*/
       - deploy-release:
+          context: reachfive
           requires:
             - test
           filters:


### PR DESCRIPTION
**Asana ticket**: https://app.asana.com/0/1141396442496489/1180780219291915

The token used to authenticate to the npm repository was invalid (probably because it was generated by Egor who has no longer access to our project). So I've created a [CircleCi context](https://circleci.com/docs/2.0/contexts/#creating-and-using-a-context) to group all the env variables required by both Web SDKs. 

This PR changes the CircleCi configuration to use the `NPM_TOKEN` variable in the `reachfive` context.