### PR TITLE
Be able to get the InAppBrowser ref (iOS purpose)

### DIFF
--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -308,15 +308,13 @@ export default class ApiClient {
         maybeBrowserTab.openUrl(url, () => {}, logError)
         return Promise.resolve()
       } else if (window.cordova.InAppBrowser) {
-        if (window.cordova.platformId === 'ios') {
+        const ref = window.cordova.platformId === 'ios' ?
           // Open a webview (to pass Apple validation tests)
-          window.cordova.InAppBrowser.open(url, '_blank')
-        } else {
+          window.cordova.InAppBrowser.open(url, '_blank') :
           // Open the system browser
           window.cordova.InAppBrowser.open(url, '_system')
-        }
 
-        return Promise.resolve()
+        return Promise.resolve(ref)
       } else {
         return Promise.reject(new Error('Cordova plugin "inappbrowser" is required.'))
       }

--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -143,7 +143,7 @@ export default class ApiClient {
     })
   }
 
-  loginWithSocialProvider(provider: string, opts: AuthOptions = {}): Promise<void> {
+  loginWithSocialProvider(provider: string, opts: AuthOptions = {}): Promise<void | Function> {
     const authParams = this.authParams({
       ...opts,
       useWebMessage: false
@@ -289,7 +289,7 @@ export default class ApiClient {
     return `${this.authorizeUrl}?${toQueryString(queryString)}`
   }
 
-  private loginWithCordovaInAppBrowser(opts: QueryString): Promise<void> {
+  private loginWithCordovaInAppBrowser(opts: QueryString): Promise<void | Function> {
     return this.openInCordovaSystemBrowser(
       this.getAuthorizationUrl({
         ...opts,
@@ -298,7 +298,7 @@ export default class ApiClient {
     )
   }
 
-  private openInCordovaSystemBrowser(url: string): Promise<void> {
+  private openInCordovaSystemBrowser(url: string): Promise<void | Function> {
     return this.getAvailableBrowserTabPlugin().then(maybeBrowserTab => {
       if (!window.cordova) {
         return Promise.reject(new Error('Cordova environnement not detected.'))

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -44,7 +44,7 @@ export type Client = {
   loginWithCredentials: (params: LoginWithCredentialsParams) => Promise<AuthResult>
   loginWithCustomToken: (params: { token: string; auth: AuthOptions }) => Promise<void>
   loginWithPassword: (params: LoginWithPasswordParams) => Promise<AuthResult>
-  loginWithSocialProvider: (provider: string, options?: AuthOptions) => Promise<void>
+  loginWithSocialProvider: (provider: string, options?: AuthOptions) => Promise<void | Function>
   loginWithWebAuthn: (params: LoginWithWebAuthnParams) => Promise<AuthResult>
   logout: (params?: { redirectTo?: string; removeCredentials?: boolean }) => Promise<void>
   off: <K extends keyof Events>(eventName: K, listener: (payload: Events[K]) => void) => void


### PR DESCRIPTION
Hello,

In order to manually manage the InAppBrowser (i.e, add event listener, be able to manually close it) for a hybrid mobile app (ionic here), I needed to get the object reference of the inappbrowser (only on iOS purpose).
See https://cordova.apache.org/docs/en/latest/reference/cordova-plugin-inappbrowser/#cordovainappbrowseropen

By doing that, we can now retrieve the InAppBrowser reference in our ionic app in the callback of the promise done when we call ```client.loginWithSocialProvider(provider)```

Is it possible to include this feature in the next release, so that I will be update my app to use the next version instead of my fork ? 

Thank's
