### PR TITLE
Release v1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.21.0] - 2021-07-30
 
 ### Features
 
-- Method to initiate an MFA step-up challenge
-- Method to list registered MFA credentials
+- Initiate an MFA step-up challenge
+- List registered MFA credentials
+- Add or remove MFA phone number credential
 
 ### Changed
 
@@ -300,7 +301,9 @@ Automatise the deployment of a new release with `circleci`.
 - Implement `tslint`.
 - Remove `yarn`.
 
-[Unreleased]: https://github.com/ReachFive/identity-web-core-sdk/compare/v1.20.1...HEAD
+[Unreleased]: https://github.com/ReachFive/identity-web-core-sdk/compare/v1.21.0...HEAD
+
+[1.21.0]: https://github.com/ReachFive/identity-web-core-sdk/compare/v1.20.1...v1.21.0
 
 [1.20.1]: https://github.com/ReachFive/identity-web-core-sdk/compare/v1.20.0...v1.20.1
 


### PR DESCRIPTION
### Features

- Initiate an MFA step-up challenge
- List registered MFA credentials
- Add or remove MFA phone number credential

### Changed

- `startPasswordless` can now can take a MFA step-up token to initiate a second factor challenge
- `startPasswordless` now returns an MFA challenge ID when using in step-up flows
- `verifyPasswordless` refactored to be able to complete second factor challenges