### PR TITLE
Ca 165 [sdk core] implement refresh token grant

### DIFF
--- a/src/main/__tests__/refreshTokens.spec.ts
+++ b/src/main/__tests__/refreshTokens.spec.ts
@@ -12,7 +12,7 @@ beforeEach(() => {
   fetchMock.resetMocks()
 })
 
-test('simple', async () => {
+test('legacy token refresh', async () => {
   // Given
   const {client, clientId, domain} = createDefaultTestClient()
 

--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -694,15 +694,24 @@ export default class ApiClient {
     return this.http.post('/unlink', { body: data, accessToken })
   }
 
-  refreshTokens({ accessToken }: { accessToken: string }): Promise<AuthResult> {
+  refreshTokens({ accessToken, refreshToken }: { accessToken?: string, refreshToken?: string }): Promise<AuthResult> {
+    if((isUndefined(refreshToken)) && !isUndefined(accessToken)) {
+      return this.http
+        .post<AuthResult>('/token/access-token', {
+          body: {
+            clientId: this.config.clientId,
+            accessToken
+          } }).then(enrichAuthResult)
+    }
+    // Ultimately the purpose is to remove the access token parameter and stop calling /token/access-token
     return this.http
-      .post<AuthResult>('/token/access-token', {
+      .post<AuthResult>(this.tokenUrl, {
         body: {
           clientId: this.config.clientId,
-          accessToken
-        }
-      })
-      .then(enrichAuthResult)
+          accessToken,
+          grantType: 'refresh_token',
+          refreshToken
+        } }).then(enrichAuthResult)
   }
 
   getUser({ accessToken, fields }: { accessToken: string; fields?: string }): Promise<Profile> {

--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -1,11 +1,9 @@
 import WinChan from 'winchan'
 import pick from 'lodash/pick'
 import isUndefined from 'lodash/isUndefined'
-
 import { logError } from '../utils/logger'
 import { QueryString, toQueryString } from '../utils/queryString'
 import { camelCaseProperties } from '../utils/transformObjectProperties'
-
 import {
   ErrorResponse,
   Profile,
@@ -42,13 +40,11 @@ export type SignupParams = {
 export type UpdateEmailParams = { accessToken: string; email: string; redirectUrl?: string }
 export type EmailVerificationParams = { accessToken: string; redirectUrl?: string; returnToAfterEmailConfirmation?: string }
 export type PhoneNumberVerificationParams = { accessToken: string }
-
 type LoginWithPasswordOptions = { password: string; saveCredentials?: boolean; auth?: AuthOptions, captchaToken?: string }
 type EmailLoginWithPasswordParams = LoginWithPasswordOptions & { email: string }
 type PhoneNumberLoginWithPasswordParams = LoginWithPasswordOptions & { phoneNumber: string }
 
 export type LoginWithPasswordParams = EmailLoginWithPasswordParams | PhoneNumberLoginWithPasswordParams
-
 export type LoginWithCredentialsParams = {
   mediation?: 'silent' | 'optional' | 'required'
   auth?: AuthOptions

--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -703,7 +703,6 @@ export default class ApiClient {
             accessToken
           } }).then(enrichAuthResult)
     }
-    // Ultimately the purpose is to remove the access token parameter and stop calling /token/access-token
     return this.http
       .post<AuthResult>(this.tokenUrl, {
         body: {

--- a/src/main/authOptions.ts
+++ b/src/main/authOptions.ts
@@ -3,6 +3,7 @@ import pick from 'lodash/pick'
 import isString from 'lodash/isString'
 import isArray from 'lodash/isArray'
 import isUndefined from 'lodash/isUndefined'
+import {Scopes} from "./models"
 
 export type ResponseType = 'code' | 'token'
 export type Prompt = 'none' | 'login' | 'consent' | 'select_account'
@@ -13,7 +14,7 @@ export type Prompt = 'none' | 'login' | 'consent' | 'select_account'
 export type AuthOptions = {
   responseType?: ResponseType
   redirectUri?: string
-  scope?: string | string[]
+  scope?: Scopes
   fetchBasicProfile?: boolean
   useWebMessage?: boolean
   popupMode?: boolean

--- a/src/main/authOptions.ts
+++ b/src/main/authOptions.ts
@@ -3,7 +3,7 @@ import pick from 'lodash/pick'
 import isString from 'lodash/isString'
 import isArray from 'lodash/isArray'
 import isUndefined from 'lodash/isUndefined'
-import {Scopes} from "./models"
+import { Scope } from "./models"
 
 export type ResponseType = 'code' | 'token'
 export type Prompt = 'none' | 'login' | 'consent' | 'select_account'
@@ -14,7 +14,7 @@ export type Prompt = 'none' | 'login' | 'consent' | 'select_account'
 export type AuthOptions = {
   responseType?: ResponseType
   redirectUri?: string
-  scope?: Scopes
+  scope?: Scope
   fetchBasicProfile?: boolean
   useWebMessage?: boolean
   popupMode?: boolean

--- a/src/main/authResult.ts
+++ b/src/main/authResult.ts
@@ -11,6 +11,7 @@ export interface AuthResult {
   idTokenPayload?: IdTokenPayload
   code?: string
   state?: string
+  refreshToken?: string
 }
 
 /**

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -21,7 +21,7 @@ import ApiClient, {
   StartMfaPhoneNumberRegistrationParams,
   VerifyMfaPhoneNumberRegistrationParams,
   StepUpParams,
-  RemoveMfaPhoneNumberParams,
+  RemoveMfaPhoneNumberParams, RefreshTokenParams,
 } from './apiClient'
 import { AuthOptions } from './authOptions'
 import { AuthResult } from './authResult'
@@ -62,7 +62,7 @@ export type Client = {
   logout: (params?: { redirectTo?: string; removeCredentials?: boolean }) => Promise<void>
   off: <K extends keyof Events>(eventName: K, listener: (payload: Events[K]) => void) => void
   on: <K extends keyof Events>(eventName: K, listener: (payload: Events[K]) => void) => void
-  refreshTokens: (params: { accessToken?: string, refreshToken?: string}) => Promise<AuthResult>
+  refreshTokens: (params: RefreshTokenParams) => Promise<AuthResult>
   remoteSettings: Promise<RemoteSettings>
   removeWebAuthnDevice: (accessToken: string, deviceId: string) => Promise<void>
   requestPasswordReset: (params: RequestPasswordResetParams) => Promise<void>
@@ -195,7 +195,7 @@ export function createClient(creationConfig: Config): Client {
     }
   }
 
-  function refreshTokens(params: { accessToken?: string, refreshToken?: string}) {
+  function refreshTokens(params: RefreshTokenParams) {
     return apiClient.then(api => api.refreshTokens(params))
   }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -62,7 +62,7 @@ export type Client = {
   logout: (params?: { redirectTo?: string; removeCredentials?: boolean }) => Promise<void>
   off: <K extends keyof Events>(eventName: K, listener: (payload: Events[K]) => void) => void
   on: <K extends keyof Events>(eventName: K, listener: (payload: Events[K]) => void) => void
-  refreshTokens: (params: { accessToken: string }) => Promise<AuthResult>
+  refreshTokens: (params: { accessToken?: string, refreshToken?: string}) => Promise<AuthResult>
   remoteSettings: Promise<RemoteSettings>
   removeWebAuthnDevice: (accessToken: string, deviceId: string) => Promise<void>
   requestPasswordReset: (params: RequestPasswordResetParams) => Promise<void>
@@ -195,7 +195,7 @@ export function createClient(creationConfig: Config): Client {
     }
   }
 
-  function refreshTokens(params: { accessToken: string }) {
+  function refreshTokens(params: { accessToken?: string, refreshToken?: string}) {
     return apiClient.then(api => api.refreshTokens(params))
   }
 

--- a/src/main/models.ts
+++ b/src/main/models.ts
@@ -130,6 +130,8 @@ export type FieldError = {
   code: 'missing' | 'invalid'
 }
 
+export type Scopes = string | string[]
+
 export namespace ErrorResponse {
   export function isErrorResponse(thing: any): thing is ErrorResponse {
     return thing && thing.error

--- a/src/main/models.ts
+++ b/src/main/models.ts
@@ -130,7 +130,7 @@ export type FieldError = {
   code: 'missing' | 'invalid'
 }
 
-export type Scopes = string | string[]
+export type Scope = string | string[]
 
 export namespace ErrorResponse {
   export function isErrorResponse(thing: any): thing is ErrorResponse {


### PR DESCRIPTION
Title:

Implementing refreshTokens endpoint with a refresh token.

Description:
The endpoint takes a refresh token as input and return an access token and a refresh token. 
The previous pairs are no longer valid.

[CA-165](https://reach5.atlassian.net/browse/CA-165)