### PR TITLE
[CA-431] Support the step up from an access_token

### DIFF
--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -10,7 +10,9 @@ import {
   SessionInfo,
   SignupProfile,
   OpenIdUser,
-  PasswordlessResponse, MFA, Scope
+  PasswordlessResponse,
+  MFA,
+  Scope
 } from './models'
 import { AuthOptions, AuthParameters, computeAuthOptions, resolveScope } from './authOptions'
 import { AuthResult, enrichAuthResult } from './authResult'
@@ -29,6 +31,7 @@ import {
 import { randomBase64String } from '../utils/random'
 import StepUpResponse = MFA.StepUpResponse
 import MfaCredentialsResponse = MFA.CredentialsResponse
+import EmailCredential = MFA.EmailCredential
 
 export type SignupParams = {
   data: SignupProfile
@@ -134,6 +137,8 @@ export type VerifyMfaPhoneNumberRegistrationParams = {
 export type StartMfaEmailRegistrationParams = {
   accessToken: string
 }
+
+export type StartMfaEmailRegistrationResponse = { status: 'email_sent' } | { status: 'enabled', credential: EmailCredential }
 
 export type VerifyMfaEmailRegistrationParams = {
   accessToken: string
@@ -919,9 +924,9 @@ export default class ApiClient {
     })
   }
 
-  startMfaEmailRegistration(params: StartMfaEmailRegistrationParams): Promise<void> {
+  startMfaEmailRegistration(params: StartMfaEmailRegistrationParams): Promise<StartMfaEmailRegistrationResponse> {
     const { accessToken } = params
-    return this.http.post<void>('/mfa/credentials/emails', {
+    return this.http.post<StartMfaEmailRegistrationResponse>('/mfa/credentials/emails', {
       accessToken
     })
   }

--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -10,9 +10,7 @@ import {
   SessionInfo,
   SignupProfile,
   OpenIdUser,
-  PasswordlessResponse,
-  MFA,
-  Scope
+  PasswordlessResponse, MFA, Scope
 } from './models'
 import { AuthOptions, AuthParameters, computeAuthOptions, resolveScope } from './authOptions'
 import { AuthResult, enrichAuthResult } from './authResult'
@@ -31,7 +29,6 @@ import {
 import { randomBase64String } from '../utils/random'
 import StepUpResponse = MFA.StepUpResponse
 import MfaCredentialsResponse = MFA.CredentialsResponse
-import EmailCredential = MFA.EmailCredential
 
 export type SignupParams = {
   data: SignupProfile
@@ -137,8 +134,6 @@ export type VerifyMfaPhoneNumberRegistrationParams = {
 export type StartMfaEmailRegistrationParams = {
   accessToken: string
 }
-
-export type StartMfaEmailRegistrationResponse = { status: 'email_sent' } | { status: 'enabled', credential: EmailCredential }
 
 export type VerifyMfaEmailRegistrationParams = {
   accessToken: string
@@ -927,9 +922,9 @@ export default class ApiClient {
     })
   }
 
-  startMfaEmailRegistration(params: StartMfaEmailRegistrationParams): Promise<StartMfaEmailRegistrationResponse> {
+  startMfaEmailRegistration(params: StartMfaEmailRegistrationParams): Promise<void> {
     const { accessToken } = params
-    return this.http.post<StartMfaEmailRegistrationResponse>('/mfa/credentials/emails', {
+    return this.http.post<void>('/mfa/credentials/emails', {
       accessToken
     })
   }

--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -145,9 +145,20 @@ export type VerifyMfaEmailRegistrationParams = {
   verificationCode: string
 }
 
+export type StepUpWithCookie = {
+  method: 'cookie'
+}
+
+export type StepUpWithAccessTokenParams = {
+  method: 'access_token',
+  accessToken: string
+}
+
+export type StepUpMethod = StepUpWithCookie | StepUpWithAccessTokenParams
+
 export type StepUpParams = {
   options?: AuthOptions
-}
+} & StepUpMethod
 
 export type RemoveMfaPhoneNumberParams = {
   accessToken: string
@@ -949,7 +960,8 @@ export default class ApiClient {
           ...authParams,
           ...challenge
         },
-        withCookies: true
+        withCookies: params.method === 'cookie',
+        accessToken: (params.method === 'access_token') ? params.accessToken : undefined
       })
     })
   }

--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -145,20 +145,18 @@ export type VerifyMfaEmailRegistrationParams = {
   verificationCode: string
 }
 
-export type StepUpWithCookie = {
+export type StepUpWithCookieParams = {
   method: 'cookie'
 }
 
 export type StepUpWithAccessTokenParams = {
-  method: 'access_token',
+  method: 'access_token'
   accessToken: string
 }
 
-export type StepUpMethod = StepUpWithCookie | StepUpWithAccessTokenParams
-
 export type StepUpParams = {
-  options?: AuthOptions
-} & StepUpMethod
+    options?: AuthOptions
+  } & (StepUpWithCookieParams | StepUpWithAccessTokenParams)
 
 export type RemoveMfaPhoneNumberParams = {
   accessToken: string

--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -135,6 +135,15 @@ export type VerifyMfaPhoneNumberRegistrationParams = {
   verificationCode: string
 }
 
+export type StartMfaEmailRegistrationParams = {
+  accessToken: string
+}
+
+export type VerifyMfaEmailRegistrationParams = {
+  accessToken: string
+  verificationCode: string
+}
+
 export type StepUpParams = {
   options?: AuthOptions
 }
@@ -142,6 +151,10 @@ export type StepUpParams = {
 export type RemoveMfaPhoneNumberParams = {
   accessToken: string
   phoneNumber: string
+}
+
+export type RemoveMfaEmailParams = {
+  accessToken: string
 }
 
 type AuthenticationToken = { tkn: string }
@@ -899,6 +912,23 @@ export default class ApiClient {
     })
   }
 
+  startMfaEmailRegistration(params: StartMfaEmailRegistrationParams): Promise<void> {
+    const { accessToken } = params
+    return this.http.post<void>('/mfa/credentials/emails', {
+      accessToken
+    })
+  }
+
+  verifyMfaEmailRegistration(params: VerifyMfaEmailRegistrationParams): Promise<void> {
+    const { accessToken, verificationCode } = params
+    return this.http.post<void>('/mfa/credentials/emails/verify', {
+      body: {
+        verificationCode
+      },
+      accessToken
+    })
+  }
+
   getMfaStepUpToken(params: StepUpParams): Promise<StepUpResponse> {
     const authParams = this.authParams(params.options ?? {})
     return this.getPkceParams(authParams).then(challenge => {
@@ -924,6 +954,13 @@ export default class ApiClient {
       body: {
         phoneNumber
       },
+      accessToken,
+    })
+  }
+
+  removeMfaEmail(params: RemoveMfaEmailParams): Promise<void> {
+    const { accessToken } = params
+    return this.http.remove<void>('/mfa/credentials/emails', {
       accessToken,
     })
   }

--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -145,18 +145,12 @@ export type VerifyMfaEmailRegistrationParams = {
   verificationCode: string
 }
 
-export type StepUpWithCookieParams = {
-  method: 'cookie'
-}
-
-export type StepUpWithAccessTokenParams = {
-  method: 'access_token'
-  accessToken: string
-}
+export type StepUpWithSessionParams = { method: 'session' }
+export type StepUpWithAccessTokenParams = { method: 'access_token', accessToken: string }
 
 export type StepUpParams = {
-    options?: AuthOptions
-  } & (StepUpWithCookieParams | StepUpWithAccessTokenParams)
+  options?: AuthOptions
+  } & (StepUpWithSessionParams | StepUpWithAccessTokenParams)
 
 export type RemoveMfaPhoneNumberParams = {
   accessToken: string
@@ -958,7 +952,7 @@ export default class ApiClient {
           ...authParams,
           ...challenge
         },
-        withCookies: params.method === 'cookie',
+        withCookies: params.method === 'session',
         accessToken: (params.method === 'access_token') ? params.accessToken : undefined
       })
     })

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -26,7 +26,6 @@ import ApiClient, {
   StartMfaEmailRegistrationParams,
   RemoveMfaEmailParams,
   RefreshTokenParams,
-  StartMfaEmailRegistrationResponse,
 } from './apiClient'
 import { AuthOptions } from './authOptions'
 import { AuthResult } from './authResult'
@@ -75,7 +74,7 @@ export type Client = {
   sendPhoneNumberVerification: (params: PhoneNumberVerificationParams) => Promise<void>
   signup: (params: SignupParams) => Promise<AuthResult>
   signupWithWebAuthn: (params: SignupWithWebAuthnParams, auth?: AuthOptions) => Promise<AuthResult>
-  startMfaEmailRegistration: (params: StartMfaEmailRegistrationParams) => Promise<StartMfaEmailRegistrationResponse>
+  startMfaEmailRegistration: (params: StartMfaEmailRegistrationParams) => Promise<void>
   startMfaPhoneNumberRegistration: (params: StartMfaPhoneNumberRegistrationParams) => Promise<void>
   startPasswordless: (params: PasswordlessParams, options?: Omit<AuthOptions, 'useWebMessage'>) => Promise<PasswordlessResponse>
   unlink: (params: { accessToken: string; identityId: string; fields?: string }) => Promise<void>

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -22,6 +22,9 @@ import ApiClient, {
   VerifyMfaPhoneNumberRegistrationParams,
   StepUpParams,
   RemoveMfaPhoneNumberParams,
+  VerifyMfaEmailRegistrationParams,
+  StartMfaEmailRegistrationParams,
+  RemoveMfaEmailParams,
 } from './apiClient'
 import { AuthOptions } from './authOptions'
 import { AuthResult } from './authResult'
@@ -70,6 +73,7 @@ export type Client = {
   sendPhoneNumberVerification: (params: PhoneNumberVerificationParams) => Promise<void>
   signup: (params: SignupParams) => Promise<AuthResult>
   signupWithWebAuthn: (params: SignupWithWebAuthnParams, auth?: AuthOptions) => Promise<AuthResult>
+  startMfaEmailRegistration: (params: StartMfaEmailRegistrationParams) => Promise<void>
   startMfaPhoneNumberRegistration: (params: StartMfaPhoneNumberRegistrationParams) => Promise<void>
   startPasswordless: (params: PasswordlessParams, options?: Omit<AuthOptions, 'useWebMessage'>) => Promise<PasswordlessResponse>
   unlink: (params: { accessToken: string; identityId: string; fields?: string }) => Promise<void>
@@ -78,11 +82,13 @@ export type Client = {
   updatePhoneNumber: (params: { accessToken: string; phoneNumber: string }) => Promise<void>
   updateProfile: (params: { accessToken: string; redirectUrl?: string; data: Profile }) => Promise<void>
   verifyPasswordless: (params: VerifyPasswordlessParams) => Promise<void>
+  verifyMfaEmailRegistration: (params: VerifyMfaEmailRegistrationParams) => Promise<void>
   verifyMfaPhoneNumberRegistration: (params: VerifyMfaPhoneNumberRegistrationParams) => Promise<void>
   verifyPhoneNumber: (params: { accessToken: string; phoneNumber: string; verificationCode: string }) => Promise<void>
   getMfaStepUpToken: (params: StepUpParams) => Promise<StepUpResponse>
   listMfaCredentials: (accessToken: string) => Promise<MfaCredentialsResponse>
   removeMfaPhoneNumber: (params: RemoveMfaPhoneNumberParams) => Promise<void>
+  removeMfaEmail: (params: RemoveMfaEmailParams) => Promise<void>
 }
 
 function checkParam<T>(data: T, key: keyof T) {
@@ -223,6 +229,10 @@ export function createClient(creationConfig: Config): Client {
     return apiClient.then(api => api.signupWithWebAuthn(params, auth))
   }
 
+  function startMfaEmailRegistration(params: StartMfaEmailRegistrationParams) {
+    return apiClient.then(api => api.startMfaEmailRegistration(params))
+  }
+
   function startMfaPhoneNumberRegistration(params: StartMfaPhoneNumberRegistrationParams) {
     return apiClient.then(api => api.startMfaPhoneNumberRegistration(params))
   }
@@ -251,6 +261,10 @@ export function createClient(creationConfig: Config): Client {
     return apiClient.then(api => api.updateProfile(params))
   }
 
+  function verifyMfaEmailRegistration(params: VerifyMfaEmailRegistrationParams) {
+    return apiClient.then(api => api.verifyMfaEmailRegistration(params))
+  }
+
   function verifyMfaPhoneNumberRegistration(params: VerifyMfaPhoneNumberRegistrationParams) {
     return apiClient.then(api => api.verifyMfaPhoneNumberRegistration(params))
   }
@@ -273,6 +287,10 @@ export function createClient(creationConfig: Config): Client {
 
   function removeMfaPhoneNumber(params: RemoveMfaPhoneNumberParams) {
     return apiClient.then(api => api.removeMfaPhoneNumber(params))
+  }
+
+  function removeMfaEmail(params: RemoveMfaEmailParams) {
+    return apiClient.then(api => api.removeMfaEmail(params))
   }
 
   return {
@@ -301,6 +319,7 @@ export function createClient(creationConfig: Config): Client {
     sendPhoneNumberVerification,
     signup,
     signupWithWebAuthn,
+    startMfaEmailRegistration,
     startMfaPhoneNumberRegistration,
     startPasswordless,
     unlink,
@@ -309,10 +328,12 @@ export function createClient(creationConfig: Config): Client {
     updatePhoneNumber,
     updateProfile,
     verifyPasswordless,
+    verifyMfaEmailRegistration,
     verifyMfaPhoneNumberRegistration,
     verifyPhoneNumber,
     getMfaStepUpToken,
     listMfaCredentials,
     removeMfaPhoneNumber,
+    removeMfaEmail,
   }
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -26,6 +26,7 @@ import ApiClient, {
   StartMfaEmailRegistrationParams,
   RemoveMfaEmailParams,
   RefreshTokenParams,
+  StartMfaEmailRegistrationResponse,
 } from './apiClient'
 import { AuthOptions } from './authOptions'
 import { AuthResult } from './authResult'
@@ -74,7 +75,7 @@ export type Client = {
   sendPhoneNumberVerification: (params: PhoneNumberVerificationParams) => Promise<void>
   signup: (params: SignupParams) => Promise<AuthResult>
   signupWithWebAuthn: (params: SignupWithWebAuthnParams, auth?: AuthOptions) => Promise<AuthResult>
-  startMfaEmailRegistration: (params: StartMfaEmailRegistrationParams) => Promise<void>
+  startMfaEmailRegistration: (params: StartMfaEmailRegistrationParams) => Promise<StartMfaEmailRegistrationResponse>
   startMfaPhoneNumberRegistration: (params: StartMfaPhoneNumberRegistrationParams) => Promise<void>
   startPasswordless: (params: PasswordlessParams, options?: Omit<AuthOptions, 'useWebMessage'>) => Promise<PasswordlessResponse>
   unlink: (params: { accessToken: string; identityId: string; fields?: string }) => Promise<void>

--- a/src/main/models.ts
+++ b/src/main/models.ts
@@ -84,7 +84,11 @@ export namespace MFA {
     return credential.type === 'sms'
   }
 
-  type CredentialType = 'sms'
+  export function isEmailCredential(credential: Credential): credential is EmailCredential {
+    return credential.type === 'email'
+  }
+
+  type CredentialType = 'sms' | 'email'
 
   type Credential = {
     type: CredentialType
@@ -95,6 +99,11 @@ export namespace MFA {
   export type PhoneCredential = Credential & {
     type: 'sms'
     phoneNumber: string
+  }
+
+  export type EmailCredential = Credential & {
+    type: 'email'
+    email: string
   }
 
   export type CredentialsResponse = {

--- a/tslint.json
+++ b/tslint.json
@@ -85,6 +85,7 @@
     "strict-string-expressions": false,
     "whitespace": false,
     "no-async-without-await": false,
-    "invalid-void": false
+    "invalid-void": false,
+    "max-file-line-count": [false]
   }
 }


### PR DESCRIPTION
[Jira](https://reach5.atlassian.net/browse/CA-431)

[PR ciam-app](https://github.com/ReachFive/ciam-app/pull/2491)

In this PR:
- existing method `getMfaStepUpToken` now expects one of:
  - `{ options?: AuthOptions, method: 'session' }`
  - `{ options?: AuthOptions, method: 'access_token', accessToken: string }`
