### PR TITLE
[CA-431] Support the step up from an access_token

### DIFF
--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -131,12 +131,10 @@ export type VerifyMfaPhoneNumberRegistrationParams = {
   verificationCode: string
 }
 
-export type StepUpWithSessionParams = { method: 'session' }
-export type StepUpWithAccessTokenParams = { method: 'access_token', accessToken: string }
-
 export type StepUpParams = {
   options?: AuthOptions
-} & (StepUpWithSessionParams | StepUpWithAccessTokenParams)
+  accessToken?: string
+}
 
 export type RemoveMfaPhoneNumberParams = {
   accessToken: string
@@ -917,8 +915,8 @@ export default class ApiClient {
           ...authParams,
           ...challenge
         },
-        withCookies: params.method === 'session',
-        accessToken: (params.method === 'access_token') ? params.accessToken : undefined
+        withCookies: params.accessToken === undefined,
+        accessToken: (params.accessToken !== undefined) ? params.accessToken : undefined
       })
     })
   }

--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -916,7 +916,7 @@ export default class ApiClient {
           ...challenge
         },
         withCookies: params.accessToken === undefined,
-        accessToken: (params.accessToken !== undefined) ? params.accessToken : undefined
+        accessToken: params.accessToken
       })
     })
   }

--- a/src/main/apiClient.ts
+++ b/src/main/apiClient.ts
@@ -131,9 +131,12 @@ export type VerifyMfaPhoneNumberRegistrationParams = {
   verificationCode: string
 }
 
+export type StepUpWithSessionParams = { method: 'session' }
+export type StepUpWithAccessTokenParams = { method: 'access_token', accessToken: string }
+
 export type StepUpParams = {
   options?: AuthOptions
-}
+} & (StepUpWithSessionParams | StepUpWithAccessTokenParams)
 
 export type RemoveMfaPhoneNumberParams = {
   accessToken: string
@@ -914,7 +917,8 @@ export default class ApiClient {
           ...authParams,
           ...challenge
         },
-        withCookies: true
+        withCookies: params.method === 'session',
+        accessToken: (params.method === 'access_token') ? params.accessToken : undefined
       })
     })
   }

--- a/tslint.json
+++ b/tslint.json
@@ -85,6 +85,7 @@
     "strict-string-expressions": false,
     "whitespace": false,
     "no-async-without-await": false,
-    "invalid-void": false
+    "invalid-void": false,
+    "max-file-line-count": [false]
   }
 }


### PR DESCRIPTION
[Jira](https://reach5.atlassian.net/browse/CA-431)

[PR ciam-app](https://github.com/ReachFive/ciam-app/pull/2491)
[PR Sandbox](https://github.com/ReachFive/reachfive-sandbox/pull/88)

In this PR:
- existing method `getMfaStepUpToken` now expects one of:
  - `{ options?: AuthOptions, method: 'session' }`
  - `{ options?: AuthOptions, method: 'access_token', accessToken: string }`
