### PR TITLE
[CA-1491] Detect & pass orchestration token when present

### DIFF
--- a/src/main/__tests__/authorize.spec.ts
+++ b/src/main/__tests__/authorize.spec.ts
@@ -108,7 +108,6 @@ describe('with redirection', () => {
           ...clientType,
           ...responseType,
           ...pageDisplay,
-          prompt: 'none',
         })
       )
     })

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -62,6 +62,7 @@ export type ApiClientConfig = {
   clientId: string
   language?: string
   scope?: string
+  orchestrationToken?: string
   sso: boolean
   pkceEnforced: boolean
   isPublic: boolean
@@ -147,10 +148,14 @@ export function createClient(creationConfig: Config): Client {
 
       const { language, sso } = remoteConfig
 
+      const params = new URLSearchParams(window.location.search)
+      const orchestrationToken = params.get('r5_request_token') || undefined
+
       const config = {
         clientId,
         baseUrl,
-        ...remoteConfig
+        orchestrationToken,
+        ...remoteConfig,
       }
 
       const http = createHttpClient({

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -4,7 +4,7 @@ import {
   SessionInfo,
   OpenIdUser,
   PasswordlessResponse,
-  MFA,
+  MFA, OrchestrationToken,
 } from './models'
 import OAuthClient, {
   LoginWithPasswordParams,
@@ -62,7 +62,7 @@ export type ApiClientConfig = {
   clientId: string
   language?: string
   scope?: string
-  orchestrationToken?: string
+  orchestrationToken?: OrchestrationToken
   sso: boolean
   pkceEnforced: boolean
   isPublic: boolean

--- a/src/main/models.ts
+++ b/src/main/models.ts
@@ -74,6 +74,8 @@ export type SessionInfo = {
   socialProviders?: string[]
 }
 
+export type OrchestrationToken = string
+
 export type AuthenticationToken = { tkn: string }
 
 export type PasswordlessResponse = MFA.ChallengeId

--- a/src/main/oAuthClient.ts
+++ b/src/main/oAuthClient.ts
@@ -694,8 +694,9 @@ export default class OAuthClient {
           ...pick(tkn, 'tkn')
         })
 
-      if (this.config.orchestrationToken) {
-        console.warn("Orchestration flow: provided parameters "+ this.reduce(authParams, correctedAuthParams) + " ignored.")
+      const uselessParams = difference(keys(authParams), keys(correctedAuthParams))
+      if (this.config.orchestrationToken && uselessParams.length !== 0) {
+        console.warn("Orchestration flow: provided parameters "+ uselessParams + " ignored.")
       }
 
       if (auth.useWebMessage) {
@@ -742,9 +743,5 @@ export default class OAuthClient {
   redirect(location: string): Promise<void> {
     window.location.assign(location)
     return Promise.resolve()
-  }
-
-  reduce(orig: object, reduced: object) {
-    return difference(keys(orig), keys(reduced))
   }
 }

--- a/src/main/oAuthClient.ts
+++ b/src/main/oAuthClient.ts
@@ -189,7 +189,6 @@ export default class OAuthClient {
     const authParams = this.authParams({
       ...opts,
       useWebMessage: false,
-      prompt: 'none',
     })
 
     return this.getPkceParams(authParams).then(maybeChallenge => {

--- a/src/main/oAuthClient.ts
+++ b/src/main/oAuthClient.ts
@@ -706,7 +706,6 @@ export default class OAuthClient {
   // In an orchestrated flow, only parameters from the original request are to be considered,
   // as well as parameters that depend on user action
   private orchestratedFlowParams(orchestrationToken: OrchestrationToken, tkn: AuthenticationToken, authOptions: AuthOptions = {}) {
-    // TODO/cbu we need redirect_uri : issue if none configured
     const authParams = computeAuthOptions(authOptions)
 
     const correctedAuthParams = {

--- a/src/main/oAuthClient.ts
+++ b/src/main/oAuthClient.ts
@@ -151,7 +151,6 @@ export default class OAuthClient {
 
       return this.getWebMessage(
           authorizationUrl,
-          this.config.baseUrl,
           opts.redirectUri,
       )
     })
@@ -300,7 +299,6 @@ export default class OAuthClient {
 
       return this.getWebMessage(
         `${this.authorizeUrl}?${queryString}`,
-        this.config.baseUrl,
         opts.redirectUri,
       ).then()
     } else {
@@ -451,7 +449,6 @@ export default class OAuthClient {
 
   private getWebMessage(
     src: string,
-    origin: string,
     redirectUri?: string,
   ): Promise<AuthResult> {
     const iframe = document.createElement('iframe')

--- a/src/main/oAuthClient.ts
+++ b/src/main/oAuthClient.ts
@@ -683,12 +683,17 @@ export default class OAuthClient {
     const authParams = this.authParams(auth)
 
     return this.getPkceParams(authParams).then(maybeChallenge => {
-      const queryString = toQueryString({
+      const queryString = (this.config.orchestrationToken) ?
+        toQueryString({
         r5_request_token: this.config.orchestrationToken,
-        ...authParams,
-        ...maybeChallenge,
+        ...pick(authParams,'persistent'),
         ...pick(tkn, 'tkn')
-      })
+      }) :
+        toQueryString({
+          ...authParams,
+          ...maybeChallenge,
+          ...pick(tkn, 'tkn')
+        })
 
       if (auth.useWebMessage) {
         return this.getWebMessage(

--- a/src/main/oAuthClient.ts
+++ b/src/main/oAuthClient.ts
@@ -684,6 +684,7 @@ export default class OAuthClient {
 
     return this.getPkceParams(authParams).then(maybeChallenge => {
       const queryString = toQueryString({
+        r5_request_token: this.config.orchestrationToken,
         ...authParams,
         ...maybeChallenge,
         ...pick(tkn, 'tkn')
@@ -722,9 +723,9 @@ export default class OAuthClient {
   }
 
   getPkceParams(authParams: AuthParameters): Promise<PkceParams | {}> {
-    if (this.config.isPublic && authParams.responseType === 'code')
+    if (this.config.isPublic && authParams.responseType === 'code' && !this.config.orchestrationToken)
       return computePkceParams()
-    else if (authParams.responseType === 'token' && this.config.pkceEnforced)
+    else if (authParams.responseType === 'token' && this.config.pkceEnforced && !this.config.orchestrationToken)
       return Promise.reject(new Error('Cannot use implicit flow when PKCE is enforced'))
     else
       return Promise.resolve({})

--- a/src/main/oAuthClient.ts
+++ b/src/main/oAuthClient.ts
@@ -196,7 +196,7 @@ export default class OAuthClient {
         ...maybeChallenge,
       }
 
-      return this.loginWithRedirect(params)
+      return this.redirectThruAuthorization(params)
     })
   }
 
@@ -279,7 +279,7 @@ export default class OAuthClient {
       } else if (params.display === 'popup') {
         return this.loginWithPopup(params)
       } else {
-        return this.loginWithRedirect(params)
+        return this.redirectThruAuthorization(params)
       }
     })
   }
@@ -302,7 +302,7 @@ export default class OAuthClient {
         opts.redirectUri,
       ).then()
     } else {
-      return this.loginWithRedirect({
+      return this.redirectThruAuthorization({
         ...authParams,
         provider,
         idToken,
@@ -552,7 +552,7 @@ export default class OAuthClient {
     }
   }
 
-  private loginWithRedirect(queryString: Record<string, string | boolean | undefined>): Promise<void> {
+  private redirectThruAuthorization(queryString: Record<string, string | boolean | undefined>): Promise<void> {
     const location = this.getAuthorizationUrl(queryString)
     window.location.assign(location)
     return Promise.resolve()
@@ -683,7 +683,7 @@ export default class OAuthClient {
     if (this.config.orchestrationToken) {
       const authParams = this.orchestratedFlowParams(this.config.orchestrationToken, tkn, auth)
 
-      return Promise.resolve().then(_ => this.loginWithRedirect(authParams) as AuthResult)
+      return Promise.resolve().then(_ => this.redirectThruAuthorization(authParams) as AuthResult)
     } else {
       const authParams = this.authParams(auth)
 
@@ -697,7 +697,7 @@ export default class OAuthClient {
         if (auth.useWebMessage) {
           return this.getWebMessage(this.getAuthorizationUrl(params), auth.redirectUri)
         } else {
-          return this.loginWithRedirect(params) as AuthResult
+          return this.redirectThruAuthorization(params) as AuthResult
         }
       })
     }


### PR DESCRIPTION
[Jira](https://reach5.atlassian.net/browse/CA-1491)

In this PR:
- detect `r5_request_token` on client creation
- when present, disable PKCE generation (as it is already defined by the initiating client)
- when present, pass it to callback flows, passwordless & SLO
- when present, pass it with the passwordless request
- when present, pass it with the social request