### PR TITLE
[CA-1769] token revocation during logout

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -12,7 +12,7 @@ import OAuthClient, {
   VerifyPasswordlessParams,
   SignupParams,
   TokenRequestParameters,
-  RefreshTokenParams, PasswordlessParams, LogoutParams, LoginWithCustomTokenParams,
+  RefreshTokenParams, PasswordlessParams, LogoutParams, LoginWithCustomTokenParams, RevocationParams,
 } from './oAuthClient'
 import { AuthOptions } from './authOptions'
 import { AuthResult } from './authResult'
@@ -263,8 +263,8 @@ export function createClient(creationConfig: Config): Client {
     return apiClients.then(clients => clients.webAuthn.loginWithWebAuthn(params))
   }
 
-  function logout(params: LogoutParams = {}) {
-    return apiClients.then(clients => clients.oAuth.logout(params))
+  function logout(params: LogoutParams = {}, revocationParams?: RevocationParams) {
+    return apiClients.then(clients => clients.oAuth.logout(params, revocationParams))
   }
 
   function off<K extends keyof Events>(eventName: K, listener: (payload: Events[K]) => void): void {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -88,7 +88,7 @@ export type Client = {
   instantiateOneTap: (opts?: AuthOptions) => void
   loginWithSocialProvider: (provider: string, options?: AuthOptions) => Promise<void | InAppBrowser>
   loginWithWebAuthn: (params: LoginWithWebAuthnParams) => Promise<AuthResult>
-  logout: (params?: LogoutParams) => Promise<void>
+  logout: (params?: LogoutParams, revocationParams?: RevocationParams) => Promise<void>
   off: <K extends keyof Events>(eventName: K, listener: (payload: Events[K]) => void) => void
   on: <K extends keyof Events>(eventName: K, listener: (payload: Events[K]) => void) => void
   refreshTokens: (params: RefreshTokenParams) => Promise<AuthResult>

--- a/src/main/oAuthClient.ts
+++ b/src/main/oAuthClient.ts
@@ -54,7 +54,7 @@ export type RevocationParams = {
   tokenTypeHint: TokenTypeHint
 }
 
-type TokenTypeHint = "access_token" | "refresh_token"
+export type TokenTypeHint = 'access_token' | 'refresh_token'
 
 export type RefreshTokenParams = { refreshToken: string, scope?: Scope }
 
@@ -378,7 +378,7 @@ export default class OAuthClient {
     if (navigator.credentials && navigator.credentials.preventSilentAccess && opts.removeCredentials === true) {
       navigator.credentials.preventSilentAccess()
     }
-    if (revocationParams) {
+    if (this.config.isPublic && revocationParams) {
       return this.revokeToken(revocationParams)
           .then(_ => window.location.assign(`${this.logoutUrl}?${toQueryString(opts)}`))
     } else {
@@ -389,6 +389,7 @@ export default class OAuthClient {
   private revokeToken(revocationParams: RevocationParams): Promise<void> {
     return this.http.post<void>(this.revokeUrl, {
       body: {
+        clientId: this.config.clientId,
         token: revocationParams.token,
         tokenTypeHint: revocationParams.tokenTypeHint
       }

--- a/src/main/oAuthClient.ts
+++ b/src/main/oAuthClient.ts
@@ -50,11 +50,8 @@ export type LogoutParams = {
 }
 
 export type RevocationParams = {
-  token: string
-  tokenTypeHint: TokenTypeHint
+  tokens: string[]
 }
-
-export type TokenTypeHint = 'access_token' | 'refresh_token'
 
 export type RefreshTokenParams = { refreshToken: string, scope?: Scope }
 
@@ -386,14 +383,15 @@ export default class OAuthClient {
     }
   }
 
-  private revokeToken(revocationParams: RevocationParams): Promise<void> {
-    return this.http.post<void>(this.revokeUrl, {
+  private revokeToken(revocationParams: RevocationParams): Promise<void[]> {
+    const revocationsCalls = revocationParams.tokens.map(token => this.http.post<void>(this.revokeUrl, {
       body: {
         clientId: this.config.clientId,
-        token: revocationParams.token,
-        tokenTypeHint: revocationParams.tokenTypeHint
+        token
       }
-    })
+    }))
+
+   return Promise.all(revocationsCalls)
   }
 
   refreshTokens(params: RefreshTokenParams): Promise<AuthResult> {


### PR DESCRIPTION
[Jira](https://reach5.atlassian.net/browse/CA-1769)
- Add optional `RevocationParams` to the `logout` function.
- If there are revocations parameters and the client is public, a call to `/oauth/revoke` is executed.