### PR TITLE
Add IdTokenPayload type missing properties

### DIFF
--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -3,21 +3,46 @@ import { decodeBase64UrlSafe } from './base64'
 
 export type Gender = 'female' | 'male' | 'other'
 
+export type Address = {
+  formatted?: string
+  streetAddress?: string
+  locality?: string
+  region?: string
+  postalCode?: string
+  country?: string
+}
+
 export interface IdTokenPayload {
+  acr?: string
+  address?: Address
+  amr?: string[]
+  atHash?: string
+  aud?: string[]
+  authTime?: number
   authType?: string
+  azp?: string
   birthdate?: string
+  customFields?: Record<string, any>
+  customIdentifier?: string
   email?: string
   emailVerified?: boolean
   exp?: number
+  externalId?: string
   familyName?: string
   gender?: Gender
   givenName?: string
   iat?: number
   iss?: string
   locale?: string
+  middleName?: string
   name?: string
   newUser?: boolean
+  nickname?: string
+  nonce?: string
+  phoneNumber?: string
+  phoneNumberVerified?: boolean
   picture?: string
+  preferredUsername?: string
   profile?: string
   sub?: string
   updatedAt?: string


### PR DESCRIPTION
Un client nous a remonté qu'ils manquant les propriétés `phoneNumber` et `address`.
J'en ai profité pour ajouter toutes celles qui manques en prenant la classe [IdToken](https://github.com/ReachFive/ciam-app/blob/develop/backend/core/src/main/scala/co/reachfive/auth/openid/response/IdToken.scala) en référence.