### PR TITLE
[CA-3273] Avoid redirection in verifyPasswordless when parameter useWebMessage is used

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -117,7 +117,7 @@ export type Client = {
   verifyMfaEmailRegistration: (params: VerifyMfaEmailRegistrationParams) => Promise<void>
   verifyMfaPasswordless: (params: VerifyMfaPasswordlessParams) => Promise<AuthResult>
   verifyMfaPhoneNumberRegistration: (params: VerifyMfaPhoneNumberRegistrationParams) => Promise<void>
-  verifyPasswordless: (params: VerifyPasswordlessParams) => Promise<void>
+  verifyPasswordless: (params: VerifyPasswordlessParams, options?: AuthOptions) => Promise<void>
   verifyPhoneNumber: (params: VerifyPhoneNumberParams) => Promise<void>
 }
 

--- a/src/main/oAuthClient.ts
+++ b/src/main/oAuthClient.ts
@@ -639,12 +639,22 @@ export default class OAuthClient {
     return Promise.resolve()
   }
 
-  private loginWithVerificationCode(params: VerifyPasswordlessParams, auth: AuthOptions = {}): void {
+  private loginWithVerificationCode(params: VerifyPasswordlessParams, auth: AuthOptions = {}): Promise<void> {
     const queryString = toQueryString({
       ...this.authParams(auth),
       ...params
     })
-    window.location.assign(`${this.passwordlessVerifyUrl}?${queryString}`)
+    if(auth.useWebMessage) {
+      return this.getWebMessage(
+        `${this.passwordlessVerifyUrl}?${queryString}`,
+        this.config.baseUrl,
+        auth.redirectUri
+      ).then()
+    } else {
+      window.location.assign(`${this.passwordlessVerifyUrl}?${queryString}`)
+      return Promise.resolve()
+    }
+
   }
 
   private ropcPasswordLogin(params: LoginWithPasswordParams): Promise<AuthResult> {


### PR DESCRIPTION
https://reach5.atlassian.net/browse/CA-3273