### PR TITLE
passwordPolicy in RemoteSettings should always be define

### DIFF
--- a/src/main/__tests__/cordova.spec.ts
+++ b/src/main/__tests__/cordova.spec.ts
@@ -28,6 +28,11 @@ function apiClientAndEventManager() {
       language: 'en',
       mfaEmailEnabled: false,
       mfaSmsEnabled: false,
+      passwordPolicy: {
+        minLength: 8,
+        minStrength: 2,
+        allowUpdateWithAccessTokenOnly: true,
+      },
       rbaEnabled: false,
       sms: false,
       socialProviders: [],

--- a/src/main/__tests__/helpers/clientFactory.ts
+++ b/src/main/__tests__/helpers/clientFactory.ts
@@ -26,6 +26,11 @@ export function createDefaultTestClient(remoteSettings: Partial<RemoteSettings> 
     webAuthn: false,
     socialProviders: [],
     customFields: [],
+    passwordPolicy: {
+      minLength: 8,
+      minStrength: 2,
+      allowUpdateWithAccessTokenOnly: true,
+    },
     resourceBaseUrl: `https://${domain}/hassets/sdk`,
     mfaEmailEnabled: false,
     mfaSmsEnabled: false,

--- a/src/main/models.ts
+++ b/src/main/models.ts
@@ -404,7 +404,7 @@ export type RemoteSettings = {
   scope?: string
   socialProviders: string[]
   googleClientId?: string,
-  passwordPolicy?: PasswordPolicy,
+  passwordPolicy: PasswordPolicy,
   consents?: Consent[],
   customFields: CustomField[],
   resourceBaseUrl: string,


### PR DESCRIPTION
According to `co.reachfive.identity.sdk.api.SdkApi.sdkConfig()` `passwordPolicy` should always be define.