### PR TITLE
loginWithSocialProvider() should return resolved/rejected promise

### DIFF
--- a/src/main/__tests__/helpers/winchanMocker.ts
+++ b/src/main/__tests__/helpers/winchanMocker.ts
@@ -8,6 +8,7 @@ class WinChanMocker {
     if (this.initialized) {
       throw new Error('Already mocked')
     }
+    this.initialized = true
     WinChan.open = jest.fn().mockImplementationOnce((params, callback) => {
       this.receivedParams = params
       callback(null, result)
@@ -18,10 +19,24 @@ class WinChanMocker {
     if (this.initialized) {
       throw new Error('Already mocked')
     }
+    this.initialized = true
     WinChan.open = jest.fn().mockImplementationOnce((params, callback) => {
       this.receivedParams = params
       callback(err)
     })
+  }
+
+  mockClear() {
+    if (jest.isMockFunction(WinChan.open)) {
+      WinChan.open.mockClear()
+    } 
+  }
+
+  mockReset() {
+    if (jest.isMockFunction(WinChan.open)) {
+      WinChan.open.mockReset()
+    } 
+    this.initialized = false
   }
 
   reset() {

--- a/src/main/__tests__/loginWithSocialProvider.spec.ts
+++ b/src/main/__tests__/loginWithSocialProvider.spec.ts
@@ -17,6 +17,7 @@ beforeEach(() => {
   jest.resetAllMocks()
   fetchMock.resetMocks()
   popNextRandomString()
+  winchanMocker.mockReset()
 })
 
 test('with default auth', async () => {
@@ -109,7 +110,13 @@ test('with popup mode with expected failure', async () => {
   client.on('authentication_failed', authenticationFailedHandler)
 
   // When
-  await client.loginWithSocialProvider('facebook', { popupMode: true })
+  await expect(
+    client.loginWithSocialProvider('facebook', { popupMode: true })
+  ).rejects.toMatchObject({
+    error: 'access_denied',
+    errorDescription: 'The user cancelled the login process',
+    errorUsrMsg: 'Login cancelled'
+  })
 
   // Then
   await expect(authenticatedHandler).not.toHaveBeenCalled()
@@ -134,7 +141,9 @@ test('with popup mode with unexpected failure', async () => {
   client.on('authentication_failed', authenticationFailedHandler)
 
   // When
-  await client.loginWithSocialProvider('facebook', { popupMode: true })
+  await expect(
+    client.loginWithSocialProvider('facebook', { popupMode: true })
+  ).rejects.toThrow('[fake error: ignore me]')
 
   // Then
   expect(authenticatedHandler).not.toHaveBeenCalled()


### PR DESCRIPTION
`loginWithSocialProvider` result is always a resolved promise, even if social login failed. It should probably return a rejected promise if failed.