### PR TITLE
Better handling of key formatter for keyx that should remains in snakecase

### DIFF
--- a/src/utils/__tests__/transformObjectProperties.spec.ts
+++ b/src/utils/__tests__/transformObjectProperties.spec.ts
@@ -21,6 +21,16 @@ const snakeCaseObject = {
       family_name: 'Pacino'
     }
   ],
+  consents: {
+    optin_testing: {
+      granted: true,
+      consent_type: "opt-in",
+      consent_version: {
+        version_id: 1,
+        language: "fr"
+      }
+    }
+  },
   tags: ['actor', 'american'],
   is_alive: true,
   test3: true
@@ -47,6 +57,16 @@ const camelCaseObject = {
       familyName: 'Pacino'
     }
   ],
+  consents: {
+    optin_testing: { // consent key should remain in snakecase
+      granted: true,
+      consentType: "opt-in",
+      consentVersion: {
+        versionId: 1,
+        language: "fr"
+      }
+    }
+  },
   tags: ['actor', 'american'],
   isAlive: true,
   test3: true

--- a/src/utils/transformObjectProperties.ts
+++ b/src/utils/transformObjectProperties.ts
@@ -26,7 +26,7 @@ type TransformObjectProperties<T> = T extends (infer U)[]
   ? { [K in keyof T]: TransformObjectProperties<T[K]> }
   : T;
 
-function transformObjectProperties<T>(input: T, transform: (path: string) => string): TransformObjectProperties<T> {
+function transformObjectProperties<T>(input: T, transform: (path: string) => string, bypass: boolean = false): TransformObjectProperties<T> {
   if (Array.isArray(input)) {
     return input.map(value => transformObjectProperties(value, transform)) as TransformObjectProperties<T>
   }
@@ -34,10 +34,8 @@ function transformObjectProperties<T>(input: T, transform: (path: string) => str
     return Object.fromEntries(
       Object.entries(input).map(([key, value]) => (
         [
-          transform(key) as keyof T,
-          fieldsNotToConvert.find(s => s === snakeCase(key))
-            ? value
-            : transformObjectProperties(value, transform)
+          bypass ? key : transform(key) as keyof T,
+          transformObjectProperties(value, transform, fieldsNotToConvert.includes(snakeCase(key)))
         ]
       ))
     ) as TransformObjectProperties<T>


### PR DESCRIPTION
Relatif à [CA-4747](https://reach5.atlassian.net/browse/CA-4747) mais traité directement dans le SDK UI.

Ici il s'agit d'améliorer le fonctionnement pour que seul les clés concernés par l'exception soient  gardés en snakecase mais pas les clés clés enfant. (voir modifications des test unitaire pour comprendre cette explication foireuse)

[CA-4747]: https://reach5.atlassian.net/browse/CA-4747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Néanmoins j'ai peur que ça introduise un breaking change pour d'éventuelles intégrations existantes...