### PR TITLE
Tiny refactoring

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,31 +1,26 @@
 {
-    "env": {
-        "browser": true,
-        "commonjs": true
-    },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "plugin:compat/recommended"
-    ],
-    "parser": "@typescript-eslint/parser",
-    "plugins": ["@typescript-eslint", "compat"],
-    "root": true,
-    "rules": {
-        "@typescript-eslint/no-namespace": "off",
-        "@typescript-eslint/no-unused-vars": ["error", {
-            "argsIgnorePattern": "^_",
-            "caughtErrorsIgnorePattern": "^_",
-            "destructuredArrayIgnorePattern": "^_",
-            "ignoreRestSiblings": true,
-            "varsIgnorePattern": "^_"
-        }]
-    },
-    "settings": {
-        "polyfills": [
-            "Promise",
-            "fetch",
-            "URLSearchParams"
-        ]
-    }
+  "env": {
+    "browser": true,
+    "commonjs": true
+  },
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:compat/recommended"],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint", "compat"],
+  "root": true,
+  "rules": {
+    "@typescript-eslint/no-namespace": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_",
+        "destructuredArrayIgnorePattern": "^_",
+        "ignoreRestSiblings": true,
+        "varsIgnorePattern": "^_"
+      }
+    ]
+  },
+  "settings": {
+    "polyfills": ["Promise", "fetch", "URL", "URLSearchParams"]
+  }
 }

--- a/src/main/__tests__/urlParser.spec.ts
+++ b/src/main/__tests__/urlParser.spec.ts
@@ -9,6 +9,87 @@ function createServices() {
 }
 
 describe('parseUrlFragment', () => {
+  test('with empty url', () => {
+    expect.assertions(1)
+
+    // Given
+    const { urlParser } = createServices()
+    // When
+    const result = urlParser.parseUrlFragment('https://example.com/login/callback')
+    // Then
+    expect(result).toBeUndefined()
+  })
+
+  test('with empty hash', () => {
+    expect.assertions(1)
+
+    // Given
+    const { urlParser } = createServices()
+    // When
+    const result = urlParser.parseUrlFragment('https://example.com/login/callback#')
+    // Then
+    expect(result).toBeUndefined()
+  })
+
+  test('with success url', () => {
+    expect.assertions(1)
+
+    // Given
+    const { urlParser } = createServices()
+
+    const idToken =
+      'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0.Pd6t82tPL3EZdkeYxw_DV2KimE1U2FvuLHmfR_mimJ5US3JFU4J2Gd94O7rwpSTGN1B9h-_lsTebo4ua4xHsTtmczZ9xa8a_kWKaSkqFjNFaFp6zcoD6ivCu03SlRqsQzSRHXo6TKbnqOt9D6Y2rNa3C4igSwoS0jUE4BgpXbc0'
+    const accessToken = 'kjbsdfljndvlksndfv'
+    const expiresIn = 1800
+    const tokenType = 'Bearer'
+    const url = `https://example.com/login/callback#${new URLSearchParams({
+      id_token: idToken,
+      access_token: accessToken,
+      expires_in: expiresIn.toString(),
+      token_type: tokenType
+    }).toString()}`
+
+    // When
+    const result = urlParser.parseUrlFragment(url)
+
+    // Then
+    expect(result).toMatchObject({
+      idToken,
+      accessToken,
+      expiresIn,
+      tokenType
+    })
+  })
+
+  test('with error url', () => {
+    expect.assertions(1)
+
+    // Given
+    const { urlParser } = createServices()
+
+    const error = 'invalid_grant'
+    const errorDescription = 'Invalid email or password'
+    const errorUsrMsg = 'Invalid email or password'
+
+    const url = `https://example.com/login/callback#${new URLSearchParams({
+      error: error,
+      error_description: errorDescription,
+      error_usr_msg: errorUsrMsg
+    }).toString()}`
+
+    // When
+    const result = urlParser.parseUrlFragment(url)
+
+    // Then
+    expect(result).toMatchObject({
+      error,
+      errorDescription,
+      errorUsrMsg
+    })
+  })
+})
+
+describe('checkUrlFragment', () => {
   test('with success url', () => {
     expect.assertions(3)
 
@@ -85,7 +166,7 @@ describe('parseUrlFragment', () => {
     })
   })
 
-  test('with url to be ignored',  () => {
+  test('with url to be ignored', () => {
     expect.assertions(3)
 
     // Given

--- a/src/main/cordovaHelper.ts
+++ b/src/main/cordovaHelper.ts
@@ -1,16 +1,16 @@
 import { UrlParser } from './urlParser'
 
 export function initCordovaCallbackIfNecessary(urlParser: UrlParser): void {
-  if (!window.cordova) return
+  if (typeof window === 'undefined' || !('cordova' in window)) return
   if (window.handleOpenURL) return
 
-  window.handleOpenURL = url => {
+  window.handleOpenURL = (url) => {
     const cordova = window.cordova
     if (!cordova) return
 
     const parsed = urlParser.checkUrlFragment(url)
 
-    if (parsed && cordova.plugins && cordova.plugins.browsertab) {
+    if (parsed && cordova?.plugins?.browsertab) {
       cordova.plugins.browsertab.close()
     }
   }

--- a/src/main/urlParser.ts
+++ b/src/main/urlParser.ts
@@ -1,7 +1,7 @@
+import { camelCaseProperties } from '../utils/transformObjectProperties'
 import { AuthResult } from './authResult'
-import { parseQueryString } from '../utils/queryString'
-import { ErrorResponse } from './models'
 import { IdentityEventManager } from './identityEventManager'
+import { ErrorResponse } from './models'
 
 export type UrlParser = {
   /**
@@ -36,17 +36,15 @@ export default function createUrlParser(eventManager: IdentityEventManager): Url
     },
 
     parseUrlFragment(url: string = ''): AuthResult | ErrorResponse | undefined {
-      const separatorIndex = url.indexOf('#')
+      const { hash } = new URL(url)
 
-      if (separatorIndex >= 0) {
-        const parsed = parseQueryString(url.substr(separatorIndex + 1))
-
-        const expiresIn = parsed.expiresIn ? parseInt(parsed.expiresIn, 10) : undefined
+      if (hash) {
+        const parsed = camelCaseProperties(Object.fromEntries(new URLSearchParams(hash).entries()))
 
         if (AuthResult.isAuthResult(parsed)) {
           return {
             ...parsed,
-            expiresIn
+            expiresIn: parsed.expiresIn ? parseInt(parsed.expiresIn, 10) : undefined
           }
         }
 

--- a/src/utils/queryString.ts
+++ b/src/utils/queryString.ts
@@ -24,9 +24,10 @@ export function parseQueryString(queryString: string): Record<string, string | u
 export function toQueryString(obj: QueryString, snakeCase = true): string {
   const params = snakeCase ? snakeCaseProperties(obj) : obj
   return Object.entries(params)
-    .filter(([_, value]) => value !== null && value !== undefined)
-    .map(([key, value]) => (
-      value !== '' ? `${key}=${encodeURIComponent(value)}` : key
-    ))
+    .filter((entry): entry is [string, string | number | boolean] => {
+      const [_, value] = entry
+      return !Array.isArray(value) && value !== null && value !== undefined
+    })
+    .map(([key, value]) => (value !== '' ? `${key}=${encodeURIComponent(value)}` : key))
     .join('&')
 }

--- a/src/utils/transformObjectProperties.ts
+++ b/src/utils/transformObjectProperties.ts
@@ -1,18 +1,10 @@
 import { camelCase, snakeCase as underlingSnakeCase } from './utils'
 
-export const snakeCasePath = (path: string) =>
-  path
-    .split('.')
-    .map(snakeCase)
-    .join('.')
-export const camelCasePath = (path: string) =>
-  path
-    .split('.')
-    .map(camelCase)
-    .join('.')
+export const snakeCasePath = (path: string) => path.split('.').map(snakeCase).join('.')
+export const camelCasePath = (path: string) => path.split('.').map(camelCase).join('.')
 
-export const camelCaseProperties = (object: object) => transformObjectProperties(object, camelCase)
-export const snakeCaseProperties = (object: object) => transformObjectProperties(object, snakeCase)
+export const camelCaseProperties = <T>(object: T) => transformObjectProperties(object, camelCase)
+export const snakeCaseProperties = <T>(object: T) => transformObjectProperties(object, snakeCase)
 
 /**
  * Won't convert the value of the field, but the field key will be converted.
@@ -24,22 +16,18 @@ type TransformObjectProperties<T> = T extends (infer U)[]
   ? TransformObjectProperties<U>[]
   : T extends Record<string, unknown>
   ? { [K in keyof T]: TransformObjectProperties<T[K]> }
-  : T;
+  : T
 
 function transformObjectProperties<T>(input: T, transform: (path: string) => string): TransformObjectProperties<T> {
   if (Array.isArray(input)) {
-    return input.map(value => transformObjectProperties(value, transform)) as TransformObjectProperties<T>
+    return input.map((value) => transformObjectProperties(value, transform)) as TransformObjectProperties<T>
   }
-  if (typeof input === "object" && input !== null) {
+  if (typeof input === 'object' && input !== null) {
     return Object.fromEntries(
-      Object.entries(input).map(([key, value]) => (
-        [
-          transform(key) as keyof T,
-          fieldsNotToConvert.find(s => s === snakeCase(key))
-            ? value
-            : transformObjectProperties(value, transform)
-        ]
-      ))
+      Object.entries(input).map(([key, value]) => [
+        transform(key) as keyof T,
+        fieldsNotToConvert.find((s) => s === snakeCase(key)) ? value : transformObjectProperties(value, transform)
+      ])
     ) as TransformObjectProperties<T>
   }
   return input as TransformObjectProperties<T>
@@ -48,5 +36,5 @@ function transformObjectProperties<T>(input: T, transform: (path: string) => str
 /* reuse Reuse lodash's _.snakeCase behavior as it covers most cases, but we want the same behavior as the
    snakecasing strategy on the server where numbers are not separated from non numbers.  */
 function snakeCase(input: string) {
-  return underlingSnakeCase(input).replace(/_\d/g, dashNumber => dashNumber.slice(1))
+  return underlingSnakeCase(input).replace(/_\d/g, (dashNumber) => dashNumber.slice(1))
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,21 +1,33 @@
 export function isEmpty(val: unknown) {
-    return val == null || !(Object.keys(val) || val).length;
+  return val == null || !(Object.keys(val) || val).length
 }
 
 export function difference<Item>(arr1: Item[], arr2: Item[]) {
-    return arr1.filter(x => !arr2.includes(x))
+  return arr1.filter((x) => !arr2.includes(x))
 }
 
-export function pick<Obj extends Record<string, unknown>, K extends keyof Obj>(object?: Obj, ...keys: K[]): { [P in K]: Obj[P] } {
-    return object 
-        ? Object.fromEntries(
-            Object.entries(object)
-                .filter(([key, value]) => keys.includes(key as K) && value !== undefined)
-        ) as { [P in K]: Obj[P] }
-        : {} as { [P in K]: Obj[P] }
+export function pick<Obj extends Record<string, unknown>, K extends keyof Obj>(
+  object?: Obj,
+  ...keys: K[]
+): { [P in K]: Obj[P] } {
+  return object
+    ? (Object.fromEntries(
+        Object.entries(object).filter(([key, value]) => keys.includes(key as K) && value !== undefined)
+      ) as { [P in K]: Obj[P] })
+    : ({} as { [P in K]: Obj[P] })
 }
 
-export function camelCase(string: string) {
+/**
+ * @example
+ * type foo = CamelCase<"foo"> // => "foo"
+ * type foo_bar = CamelCase<"foo_bar"> // =>"fooBar"
+ * type foo_bar_baz = CamelCase<"foo_bar_baz"> // => "fooBarBaz"
+ */
+export type CamelCase<S extends string> = S extends `${infer T}_${infer U}` 
+  ? `${Lowercase<T>}${Capitalize<CamelCase<U>>}`
+  : Lowercase<S>;
+
+export function camelCase<S extends string>(string: S): CamelCase<S> {
     return string
     .replace(/([^A-Z])([A-Z])/g, '$1 $2') // "aB" become "a B"
     .toLowerCase()
@@ -24,10 +36,10 @@ export function camelCase(string: string) {
     .replace(/(?:^\w|[A-Z]|\b\w)/g, function(word, index) {
         return index === 0 ? word.toLowerCase() : word.toUpperCase();
     })
-    .replace(/\s+/g, '');
+    .replace(/\s+/g, '') as CamelCase<S>;
 }
 
 export function snakeCase(string: string) {
-    const matches = string.match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+|[A-Z]|[0-9]+/g)
-    return matches ? matches.map(s => s.toLowerCase()).join('_') : '';
+  const matches = string.match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+|[A-Z]|[0-9]+/g)
+  return matches ? matches.map((s) => s.toLowerCase()).join('_') : ''
 }


### PR DESCRIPTION
- utilisation de `URLSearchParams` pour parser les query parameters (qui sont en fait dans le hash?!) dans `parseUrlFragment`
- revue des tests de urlParser pour tester séparément `parseUrlFragment` et `checkUrlFragment`
- une ou deux améliorations de typage
- un peu de formatage automatique...