### PR TITLE
[CA-4940] Pouvoir tracer l'origine lors d'une demande de réinitialisation de mot de passe

### DIFF
--- a/src/main/__tests__/requestPasswordReset.spec.ts
+++ b/src/main/__tests__/requestPasswordReset.spec.ts
@@ -1,7 +1,7 @@
 import fetchMock from 'jest-fetch-mock'
 
-import { defineWindowProperty, headers } from './helpers/testHelpers'
 import { createDefaultTestClient } from './helpers/clientFactory'
+import { defineWindowProperty, headers } from './helpers/testHelpers'
 
 beforeAll(() => {
   fetchMock.enableMocks()
@@ -29,6 +29,29 @@ test('simple', async () => {
       body: JSON.stringify({
         client_id: clientId,
         email
+      })
+    })
+  })
+})
+
+test('with origin', async () => {
+  const { client, clientId, domain } = createDefaultTestClient()
+
+  const passwordResetCall = fetchMock.mockResponseOnce('', {
+    status: 204
+  })
+
+  const email = 'john.doe@example.com'
+  const origin = 'sdk-core'
+
+  client.requestPasswordReset({ email, origin }).then(() => {
+    expect(passwordResetCall).toHaveBeenCalledWith(`https://${domain}/identity/v1/forgot-password`, {
+      method: 'POST',
+      headers: headers.jsonAndDefaultLang,
+      body: JSON.stringify({
+        client_id: clientId,
+        email,
+        origin
       })
     })
   })

--- a/src/main/captcha.ts
+++ b/src/main/captcha.ts
@@ -1,1 +1,6 @@
 export type CaptchaProvider = 'recaptcha' | 'captchafox'
+
+export type CaptchaParams = {
+  captchaToken?: string
+  captchaProvider?: CaptchaProvider
+}

--- a/src/main/oAuthClient.ts
+++ b/src/main/oAuthClient.ts
@@ -1,34 +1,34 @@
+import { Buffer } from 'buffer/'
+import * as OneTap from "google-one-tap"
 import WinChan from 'winchan'
+import { encodeToBase64 } from "../utils/base64"
 import { logError } from '../utils/logger'
 import { QueryString, toQueryString } from '../utils/queryString'
+import { randomBase64String } from '../utils/random'
+import { getWithExpiry, setWithExpiry } from '../utils/sessionStorage'
 import { camelCaseProperties } from '../utils/transformObjectProperties'
 import { difference, pick } from '../utils/utils'
+import { AuthOptions, computeAuthOptions } from './authOptions'
+import { AuthParameters } from './authParameters'
+import { AuthResult, enrichAuthResult } from './authResult'
+import { CaptchaParams } from './captcha'
+import { HttpClient } from './httpClient'
+import { IdentityEventManager } from './identityEventManager'
+import { ApiClientConfig } from './main'
+import MfaClient from './mfaClient'
 import {
+  AuthenticationToken,
   ErrorResponse,
+  OrchestrationToken,
+  PasswordlessResponse,
+  PasswordStrength,
+  Scope,
   SessionInfo,
   SignupProfile,
-  PasswordlessResponse,
-  Scope,
-  AuthenticationToken, OrchestrationToken,
-  PasswordStrength,
 } from './models'
-import { AuthOptions, computeAuthOptions } from './authOptions'
-import { AuthResult, enrichAuthResult } from './authResult'
-import { IdentityEventManager } from './identityEventManager'
-import { popupSize } from './providerPopupSize'
-import { HttpClient } from './httpClient'
 import { computePkceParams, PkceParams } from './pkceService'
-import { randomBase64String } from '../utils/random'
-import { ApiClientConfig } from './main'
-import { AuthParameters } from './authParameters'
+import { popupSize } from './providerPopupSize'
 import { resolveScope } from './scopeHelper'
-import * as OneTap from "google-one-tap"
-import { encodeToBase64 } from "../utils/base64"
-import { Buffer } from 'buffer/'
-import MfaClient from './mfaClient'
-import { getWithExpiry, setWithExpiry } from '../utils/sessionStorage'
-import { CaptchaProvider } from './captcha'
-
 export type LoginWithCredentialsParams = {
   mediation?: 'silent' | 'optional' | 'required'
   auth?: AuthOptions
@@ -39,7 +39,7 @@ export type LoginWithCustomTokenParams = {
   auth: AuthOptions
 }
 
-type LoginWithPasswordOptions = { password: string; saveCredentials?: boolean; auth?: AuthOptions, captchaToken?: string, action?: string }
+type LoginWithPasswordOptions = { password: string; saveCredentials?: boolean; auth?: AuthOptions, action?: string } & CaptchaParams
 type EmailLoginWithPasswordParams = LoginWithPasswordOptions & { email: string }
 type PhoneNumberLoginWithPasswordParams = LoginWithPasswordOptions & { phoneNumber: string }
 type CustomIdentifierLoginWithPasswordParams = LoginWithPasswordOptions & { customIdentifier: string }
@@ -60,9 +60,7 @@ export type SingleFactorPasswordlessParams = {
   authType: 'magic_link' | 'sms'
   email?: string
   phoneNumber?: string
-  captchaToken?: string
-  captchaProvider?: CaptchaProvider;
-}
+} & CaptchaParams
 
 export type StepUpPasswordlessParams = {
   authType: 'email' | 'sms'
@@ -77,9 +75,7 @@ export type SignupParams = {
   saveCredentials?: boolean
   auth?: AuthOptions
   redirectUrl?: string
-  captchaToken?: string
-  captchaProvider?: CaptchaProvider
-}
+} & CaptchaParams
 
 export type TokenRequestParameters = {
   code: string

--- a/src/main/profileClient.ts
+++ b/src/main/profileClient.ts
@@ -1,31 +1,36 @@
-import {
-  Profile,
-  OpenIdUser,
-} from './models'
-import { IdentityEventManager } from './identityEventManager'
-import { HttpClient } from './httpClient'
-import { ApiClientConfig } from './main'
-import { CaptchaProvider } from './captcha'
+import type { CaptchaParams } from './captcha'
+import type { HttpClient } from './httpClient'
+import type { IdentityEventManager } from './identityEventManager'
+import type { ApiClientConfig } from './main'
+import type { OpenIdUser, Profile } from './models'
 
-export type UpdateEmailParams = { accessToken: string; email: string; redirectUrl?: string; captchaToken?: string, captchaProvider?: string }
+export type UpdateEmailParams = {
+  accessToken: string
+  email: string
+  redirectUrl?: string
+} & CaptchaParams
 
-export type EmailVerificationParams = { accessToken: string; redirectUrl?: string; returnToAfterEmailConfirmation?: string }
+export type EmailVerificationParams = {
+  accessToken: string
+  redirectUrl?: string
+  returnToAfterEmailConfirmation?: string
+}
 
 export type PhoneNumberVerificationParams = { accessToken: string }
 
 type EmailRequestPasswordResetParams = {
   email: string
-  redirectUrl?: string
   loginLink?: string
+  origin?: string
+  redirectUrl?: string
   returnToAfterPasswordReset?: string
-  captchaToken?: string
-  captchaProvider?: CaptchaProvider
-}
+} & CaptchaParams
+
 type SmsRequestPasswordResetParams = {
   phoneNumber: string
-  captchaToken?: string
-  captchaProvider?: CaptchaProvider
-}
+  origin?: string
+} & CaptchaParams
+
 export type RequestPasswordResetParams = EmailRequestPasswordResetParams | SmsRequestPasswordResetParams
 
 type EmailRequestAccountRecoveryParams = {
@@ -33,14 +38,12 @@ type EmailRequestAccountRecoveryParams = {
   redirectUrl?: string
   loginLink?: string
   returnToAfterAccountRecovery?: string
-  captchaToken?: string
-  captchaProvider?: CaptchaProvider
-}
+} & CaptchaParams
+
 type SmsRequestAccountRecoveryParams = {
   phoneNumber: string
-  captchaToken?: string
-  captchaProvider?: CaptchaProvider
-}
+} & CaptchaParams
+
 export type RequestAccountRecoveryParams = EmailRequestAccountRecoveryParams | SmsRequestAccountRecoveryParams
 
 type AccessTokenUpdatePasswordParams = {
@@ -197,8 +200,8 @@ export default class ProfileClient {
   updateProfile(params: UpdateProfileParams): Promise<void> {
     const { accessToken, redirectUrl, data } = params
     return this.http
-        .post(this.updateProfileUrl, { body: { ...data, redirectUrl }, accessToken })
-        .then(() => this.eventManager.fireEvent('profile_updated', data))
+      .post(this.updateProfileUrl, { body: { ...data, redirectUrl }, accessToken })
+      .then(() => this.eventManager.fireEvent('profile_updated', data))
   }
 
   updatePassword(params: UpdatePasswordParams): Promise<void> {
@@ -213,13 +216,14 @@ export default class ProfileClient {
     const { accessToken, ...data } = params
     const { phoneNumber } = data
     return this.http
-        .post(this.verifyPhoneNumberUrl, { body: data, accessToken })
-        .then(() => this.eventManager.fireEvent('profile_updated', { phoneNumber, phoneNumberVerified: true }))
+      .post(this.verifyPhoneNumberUrl, { body: data, accessToken })
+      .then(() => this.eventManager.fireEvent('profile_updated', { phoneNumber, phoneNumberVerified: true }))
   }
 
   verifyEmail(params: VerifyEmailParams): Promise<void> {
     const { email } = params
-    return this.http.post<void>(this.verifyEmailUrl, { body: params })
-      .then(() => this.eventManager.fireEvent("profile_updated", {email, emailVerified: true}))
+    return this.http
+      .post<void>(this.verifyEmailUrl, { body: params })
+      .then(() => this.eventManager.fireEvent('profile_updated', { email, emailVerified: true }))
   }
 }


### PR DESCRIPTION
[CA-4940](https://reach5.atlassian.net/browse/CA-4940)

J'en ai profité pour mutualiser les paramètres relatif à l'utilisation du captcha dans un type commun (via `extends`)