### PR TITLE
[CA-5381] Avoid to automatically exchange authentication code when useWebMessage is true and the client is private

### DIFF
--- a/src/main/oAuthClient.ts
+++ b/src/main/oAuthClient.ts
@@ -567,7 +567,7 @@ export default class OAuthClient {
         const result = data.response
 
         if (AuthResult.isAuthResult(result)) {
-          if (result.code) {
+          if (result.code && this.config.isPublic) {
             resolve(this.exchangeAuthorizationCodeWithPkce({
               code: result.code,
               redirectUri: redirectUri || window.location.origin,


### PR DESCRIPTION
https://reach5.atlassian.net/browse/CA-5381